### PR TITLE
chore: update OpenVidu/actions to v1.0.18

### DIFF
--- a/.github/workflows/publish-web.yaml
+++ b/.github/workflows/publish-web.yaml
@@ -31,7 +31,7 @@ jobs:
         with:
           python-version: 3.x
       - name: Install safe-chain
-        uses: OpenVidu/actions/install-safe-chain@0125dee363f943e399bf576e8e4c162fafcc5bdd # v1.0.16
+        uses: OpenVidu/actions/install-safe-chain@e585b0ac266d7afffc6cba105b380ad6a477a4c0 # v1.0.18
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Updates pinned references of `OpenVidu/actions` to `v1.0.18`.

Auto-generated by the [update-pinned-actions](https://github.com/OpenVidu/actions/actions/workflows/update-pinned-actions.yml) workflow.