### PR TITLE
chore: update OpenVidu/actions to v1.0.21

### DIFF
--- a/.github/workflows/publish-web.yaml
+++ b/.github/workflows/publish-web.yaml
@@ -31,7 +31,7 @@ jobs:
         with:
           python-version: 3.x
       - name: Install safe-chain
-        uses: OpenVidu/actions/install-safe-chain@1eb0c5759951f915de29647dedfa1ec8fbb5eeac # v1.0.20
+        uses: OpenVidu/actions/install-safe-chain@040cbfd01320475801d7b12e33769e0d55a737a8 # v1.0.21
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Updates pinned references of `OpenVidu/actions` to `v1.0.21`.

Auto-generated by the [update-pinned-actions](https://github.com/OpenVidu/actions/actions/workflows/update-pinned-actions.yml) workflow.