### PR TITLE
JSON-LD proposal for the website

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -91,6 +91,7 @@
 {% block extrahead %}
 <!-- Add head tags that need to be applied before here -->
 {{ super() }}
+{% include "partials/json-ld.html" %}
 <!-- Add head tags that need to be applied afterwards here -->
 {% endblock %}
 

--- a/docs/overrides/partials/json-ld.html
+++ b/docs/overrides/partials/json-ld.html
@@ -5,6 +5,8 @@
     - Homepage (index.md): Organization + WebSite + the two products (@graph)
     - OpenVidu Meet product page (meet/index.md): SoftwareApplication
     - OpenVidu Platform product page (docs/index.md): SoftwareApplication
+    - Any page with a `faq:` list in its frontmatter (pricing.md): FAQPage
+      with one Question/Answer per entry
     - Any page with a `publications:` list in its frontmatter (research.md):
       one ScholarlyArticle/Thesis per publication, with authors (ORCID),
       venue, DOI, images and abstract
@@ -127,6 +129,34 @@
   "@graph": [
 {{ organization() }},
 {{ platform_app() }}
+  ]
+}
+</script>
+{%- elif page and page.meta and page.meta.faq %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+{{ organization() }},
+    {
+      "@type": "FAQPage",
+      "@id": {{ (page.canonical_url ~ "#faq") | tojson }},
+      "mainEntity": [
+        {%- for item in page.meta.faq %}
+        {
+          "@type": "Question",
+          "name": {{ item.question | tojson }},
+          {%- if item.anchor %}
+          "url": {{ (page.canonical_url ~ "#" ~ item.anchor) | tojson }},
+          {%- endif %}
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": {{ item.answer | tojson }}
+          }
+        }{{ "," if not loop.last }}
+        {%- endfor %}
+      ]
+    }
   ]
 }
 </script>

--- a/docs/overrides/partials/json-ld.html
+++ b/docs/overrides/partials/json-ld.html
@@ -5,6 +5,7 @@
     - Homepage (index.md): Organization + WebSite + the two products (@graph)
     - OpenVidu Meet product page (meet/index.md): SoftwareApplication
     - OpenVidu Platform product page (docs/index.md): SoftwareApplication
+    - Blog index (blog/index.md): Blog with the list of posts in the view
     - Blog posts (blog/posts/*): BlogPosting with authors, dates and publisher
     - Any other page: nothing
 
@@ -123,6 +124,38 @@
   "@graph": [
 {{ organization() }},
 {{ platform_app() }}
+  ]
+}
+</script>
+{%- elif page and page.file and page.file.src_uri == "blog/index.md" %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+{{ organization() }},
+    {
+      "@type": "Blog",
+      "@id": "https://openvidu.io/blog/#blog",
+      "name": "OpenVidu Blog",
+      "url": "https://openvidu.io/blog/",
+      "description": "Articles on self-hosted videoconferencing, WebRTC development, benchmarks and OpenVidu product news, written by the OpenVidu team.",
+      "inLanguage": "en",
+      "publisher": { "@id": "https://openvidu.io/#organization" }
+      {%- if page.posts %},
+      "blogPost": [
+        {%- for post in page.posts %}
+        {
+          "@type": "BlogPosting",
+          "headline": {{ post.title | string | tojson }},
+          "url": {{ post.canonical_url | tojson }}
+          {%- if post.config and post.config.date and post.config.date.created %},
+          "datePublished": {{ post.config.date.created.strftime("%Y-%m-%d") | tojson }}
+          {%- endif %}
+        }{{ "," if not loop.last }}
+        {%- endfor %}
+      ]
+      {%- endif %}
+    }
   ]
 }
 </script>

--- a/docs/overrides/partials/json-ld.html
+++ b/docs/overrides/partials/json-ld.html
@@ -5,6 +5,9 @@
     - Homepage (index.md): Organization + WebSite + the two products (@graph)
     - OpenVidu Meet product page (meet/index.md): SoftwareApplication
     - OpenVidu Platform product page (docs/index.md): SoftwareApplication
+    - Any page with a `publications:` list in its frontmatter (research.md):
+      one ScholarlyArticle/Thesis per publication, with authors (ORCID),
+      venue, DOI, images and abstract
     - Blog index (blog/index.md): Blog with the list of posts in the view
     - Blog posts (blog/posts/*): BlogPosting with authors, dates and publisher
     - Any other page: nothing
@@ -124,6 +127,84 @@
   "@graph": [
 {{ organization() }},
 {{ platform_app() }}
+  ]
+}
+</script>
+{%- elif page and page.meta and page.meta.publications %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+{{ organization() }}
+    {%- for pub in page.meta.publications %},
+    {
+      "@type": {{ '"Thesis"' if pub.kind == "phdthesis" else '"ScholarlyArticle"' }},
+      "@id": {{ (page.canonical_url ~ "#" ~ pub.anchor) | tojson }},
+      "headline": {{ pub.title | tojson }},
+      "url": {{ pub.url | tojson }},
+      "mainEntityOfPage": {{ page.canonical_url | tojson }},
+      "datePublished": {{ pub.year | string | tojson }},
+      "inLanguage": "en",
+      {%- if pub.doi %}
+      "sameAs": {{ ("https://doi.org/" ~ pub.doi) | tojson }},
+      "identifier": {
+        "@type": "PropertyValue",
+        "propertyID": "DOI",
+        "value": {{ pub.doi | tojson }}
+      },
+      {%- endif %}
+      {%- if pub.venue %}
+      {%- if pub.kind == "phdthesis" %}
+      "sourceOrganization": {
+        "@type": "CollegeOrUniversity",
+        "name": {{ pub.venue | tojson }}
+      },
+      {%- elif pub.kind == "journal" %}
+      "isPartOf": {
+        "@type": "Periodical",
+        "name": {{ pub.venue | tojson }}
+      },
+      {%- else %}
+      "isPartOf": {
+        "@type": "CreativeWork",
+        "name": {{ pub.venue | tojson }}
+      },
+      {%- endif %}
+      {%- endif %}
+      {%- if pub.images %}
+      "image": [
+        {%- for img in pub.images %}
+        {{ ("https://openvidu.io" ~ img) | tojson }}{{ "," if not loop.last }}
+        {%- endfor %}
+      ],
+      {%- endif %}
+      {%- if pub.abstract %}
+      "abstract": {{ pub.abstract | tojson }},
+      {%- endif %}
+      "author": [
+        {%- for author in pub.authors %}
+        {
+          "@type": "Person",
+          "name": {{ author.name | tojson }}{% if author.orcid %},
+          "@id": {{ author.orcid | tojson }},
+          "sameAs": {{ author.orcid | tojson }}{% endif %}
+        }{{ "," if not loop.last }}
+        {%- endfor %}
+      ]
+      {%- if pub.contributors %},
+      "contributor": [
+        {%- for author in pub.contributors %}
+        {
+          "@type": "Person",
+          "name": {{ author.name | tojson }}{% if author.orcid %},
+          "@id": {{ author.orcid | tojson }},
+          "sameAs": {{ author.orcid | tojson }}{% endif %}
+        }{{ "," if not loop.last }}
+        {%- endfor %}
+      ]
+      {%- endif %}
+    }
+    {%- endfor %}
   ]
 }
 </script>

--- a/docs/overrides/partials/json-ld.html
+++ b/docs/overrides/partials/json-ld.html
@@ -1,0 +1,170 @@
+{#-
+  JSON-LD structured data (schema.org) for search engines.
+
+  What gets emitted, per page type:
+    - Homepage (index.md): Organization + WebSite + the two products (@graph)
+    - OpenVidu Meet product page (meet/index.md): SoftwareApplication
+    - OpenVidu Platform product page (docs/index.md): SoftwareApplication
+    - Blog posts (blog/posts/*): BlogPosting with authors, dates and publisher
+    - Any other page: nothing
+
+  URL policy: product URLs are hardcoded to their canonical "latest" form
+  (https://openvidu.io/latest/meet/ and /latest/docs/) so structured data
+  always consolidates ranking signals on the canonical URL, never on a
+  pinned version. Blog posts use page.canonical_url: they are non-versioned
+  pages, and the deploy script (custom-versioning/push-new-version.sh)
+  already strips the version segment from their HTML.
+-#}
+
+{%- macro organization() -%}
+    {
+      "@type": "Organization",
+      "@id": "https://openvidu.io/#organization",
+      "name": "OpenVidu",
+      "url": "https://openvidu.io/",
+      "description": "Self-hosted videoconferencing and custom WebRTC solutions: OpenVidu Meet, a ready-to-use video calling solution, and OpenVidu Platform, SDKs to build custom real-time applications. Self-hosted, performant, scalable and fault tolerant.",
+      "logo": {
+        "@type": "ImageObject",
+        "url": "https://openvidu.io/assets/images/openvidu_vert_white_bg_trans_cropped2.png"
+      },
+      "sameAs": [
+        "https://github.com/OpenVidu",
+        "https://x.com/openvidu",
+        "https://openvidu.medium.com/",
+        "https://www.youtube.com/@openvidu"
+      ],
+      "contactPoint": {
+        "@type": "ContactPoint",
+        "contactType": "customer support",
+        "url": "https://openvidu.io/support/"
+      }
+    }
+{%- endmacro -%}
+
+{%- macro website() -%}
+    {
+      "@type": "WebSite",
+      "@id": "https://openvidu.io/#website",
+      "name": "OpenVidu",
+      "url": "https://openvidu.io/",
+      "inLanguage": "en",
+      "publisher": { "@id": "https://openvidu.io/#organization" }
+    }
+{%- endmacro -%}
+
+{%- macro meet_app() -%}
+    {
+      "@type": "SoftwareApplication",
+      "@id": "https://openvidu.io/latest/meet/#software",
+      "name": "OpenVidu Meet",
+      "url": "https://openvidu.io/latest/meet/",
+      "description": "Ready-to-use, self-hosted videoconferencing solution. Create rooms, record meetings and embed high-quality video calls into any website or application with minimal code.",
+      "applicationCategory": "CommunicationApplication",
+      "operatingSystem": "Linux (self-hosted server), any modern web browser (client)",
+      "offers": {
+        "@type": "Offer",
+        "price": "0",
+        "priceCurrency": "EUR",
+        "description": "OpenVidu COMMUNITY edition is open source and free to self-host. OpenVidu PRO adds scalability, fault tolerance and advanced features.",
+        "url": "https://openvidu.io/pricing/"
+      },
+      "author": { "@id": "https://openvidu.io/#organization" },
+      "publisher": { "@id": "https://openvidu.io/#organization" }
+    }
+{%- endmacro -%}
+
+{%- macro platform_app() -%}
+    {
+      "@type": "SoftwareApplication",
+      "@id": "https://openvidu.io/latest/docs/#software",
+      "name": "OpenVidu Platform",
+      "url": "https://openvidu.io/latest/docs/",
+      "description": "Programmable platform with client and server SDKs to build custom, self-hosted WebRTC applications: videoconferencing, live streaming and AI-powered real-time media with low latency, scalability and fault tolerance.",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "Linux (self-hosted server); client SDKs for browsers, Android and iOS",
+      "offers": {
+        "@type": "Offer",
+        "price": "0",
+        "priceCurrency": "EUR",
+        "description": "OpenVidu COMMUNITY edition is open source and free to self-host. OpenVidu PRO adds scalability, fault tolerance and advanced features.",
+        "url": "https://openvidu.io/pricing/"
+      },
+      "author": { "@id": "https://openvidu.io/#organization" },
+      "publisher": { "@id": "https://openvidu.io/#organization" }
+    }
+{%- endmacro -%}
+
+{%- if page and page.file and page.file.src_uri == "index.md" %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+{{ organization() }},
+{{ website() }},
+{{ meet_app() }},
+{{ platform_app() }}
+  ]
+}
+</script>
+{%- elif page and page.file and page.file.src_uri == "meet/index.md" %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+{{ organization() }},
+{{ meet_app() }}
+  ]
+}
+</script>
+{%- elif page and page.file and page.file.src_uri == "docs/index.md" %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+{{ organization() }},
+{{ platform_app() }}
+  ]
+}
+</script>
+{%- elif page and page.file and page.file.src_uri.startswith("blog/posts/") %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+{{ organization() }},
+    {
+      "@type": "BlogPosting",
+      "@id": {{ page.canonical_url | tojson }},
+      "mainEntityOfPage": {{ page.canonical_url | tojson }},
+      "url": {{ page.canonical_url | tojson }},
+      "headline": {{ page.title | string | tojson }},
+      {%- if page.meta.description %}
+      "description": {{ page.meta.description | tojson }},
+      {%- endif %}
+      {%- if page.meta.image %}
+      "image": {{ (page.meta.image if page.meta.image.startswith("http") else "https://openvidu.io" ~ page.meta.image) | tojson }},
+      {%- endif %}
+      {%- if page.config and page.config.date and page.config.date.created %}
+      "datePublished": {{ page.config.date.created.strftime("%Y-%m-%d") | tojson }},
+      "dateModified": {{ (page.config.date.updated or page.config.date.created).strftime("%Y-%m-%d") | tojson }},
+      {%- endif %}
+      "inLanguage": "en",
+      {%- if page.authors %}
+      "author": [
+        {%- for author in page.authors %}
+        {
+          "@type": "Person",
+          "name": {{ author.name | tojson }}{% if author.url and author.url.startswith("http") %},
+          "url": {{ author.url | tojson }}{% endif %}
+        }{{ "," if not loop.last }}
+        {%- endfor %}
+      ],
+      {%- else %}
+      "author": { "@id": "https://openvidu.io/#organization" },
+      {%- endif %}
+      "publisher": { "@id": "https://openvidu.io/#organization" }
+    }
+  ]
+}
+</script>
+{%- endif %}

--- a/docs/pricing.md
+++ b/docs/pricing.md
@@ -1,6 +1,23 @@
 ---
 title: Pricing
 description: Discover OpenVidu's transparent pricing for Community (free) and Pro editions.
+# Structured Q&A metadata for this page's FAQ sections. It feeds the JSON-LD
+# (schema.org FAQPage) emitted by overrides/partials/json-ld.html. Keep in
+# sync with the page content below: 'anchor' must match the heading id, and
+# each answer must summarize the visible content of its section.
+faq:
+  - anchor: how-is-openvidu-pro-priced
+    question: "How is OpenVidu Pro priced?"
+    answer: >-
+      OpenVidu Pro follows a simple pay-per-use model based on the number of cores available to your OpenVidu Pro cluster: $0.0006 per core per minute. You only pay while the cluster is running (usage is registered from cluster start to shutdown, including idle time), and you pay for every available core at any given time — Master Nodes and Media Nodes have the same core-per-minute price. If your cluster grows, that hour costs more; if it shrinks, the next hour is cheaper. OpenVidu COMMUNITY is completely open source and free to use.
+  - anchor: why-is-openvidu-pro-priced-like-this
+    question: "Why is OpenVidu Pro priced like this?"
+    answer: >-
+      A platform specifically designed to be self-hosted should have a pricing model as close to hardware as possible: the total number of cores available to the cluster over time. This model is simple, transparent and easy to predict — you pay only for the time the cluster is running and always according to its size. The cost is directly proportional to the size of your cluster, and elasticity is encouraged: adjust the size of your cluster according to the load at any given time to minimize costs.
+  - anchor: when-and-how-are-you-charged
+    question: "When and how are you charged?"
+    answer: >-
+      You need an OpenVidu account and an OpenVidu License to deploy an OpenVidu Pro cluster (OpenVidu Elastic or OpenVidu High Availability). When purchasing a license you indicate your billing address and a credit card, and you receive a 15-day free trial period during which you are not charged at all. After the trial, a monthly billing cycle charges your expenses to your credit card and you receive an invoice each month. The entire billing process is securely done via Stripe and no credit card data is stored. OpenVidu Pro clusters automatically report their usage, which requires outbound access to accounts.openvidu.io on port 443.
 hide:
   - navigation
   - toc

--- a/docs/research.md
+++ b/docs/research.md
@@ -10,6 +10,380 @@ hide:
 tags:
   - dropdown
   - setupwowjs
+# Structured metadata for the publications listed on this page. It feeds the
+# JSON-LD (schema.org ScholarlyArticle/Thesis) emitted by
+# overrides/partials/json-ld.html. Keep in sync with the page content below:
+# 'anchor' must match the heading id linked from the index table.
+publications:
+  - kind: phdthesis
+    anchor: scalability-and-quality-of-experience-of-webrtc-media-servers-for-large-scale-low-latency-streaming
+    title: "Scalability and Quality of Experience of WebRTC media servers for Large-Scale, Low-Latency Streaming"
+    url: https://dialnet.unirioja.es/servlet/tesis?codigo=402576
+    year: 2026
+    venue: Universidad Rey Juan Carlos
+    authors:
+      - name: Iván Chicano-Capelo
+        orcid: https://orcid.org/0000-0003-1857-9615
+    contributors:
+      - name: Francisco Gortázar
+        orcid: https://orcid.org/0000-0002-2183-0869
+      - name: Micael Gallego
+        orcid: https://orcid.org/0000-0002-2875-7342
+    images:
+      - /assets/images/research/thesis-webrtc-scaling-architecture-alg-C.png
+      - /assets/images/research/thesis-servers-in-use.png
+    abstract: >-
+      Low-Latency Live Streaming (LLLS) has become a cornerstone for interactive applications such as virtual events, gaming, and real-time collaboration. Web Real-Time Communication (WebRTC), originally designed for peer-to-peer communication, is increasingly adopted for LLLS due to its sub-second latency and native browser support. However, scaling WebRTC to thousands of concurrent viewers while preserving the Quality of Experience (QoE) of the users remains challenging. This thesis posits that WebRTC can be used for massive LLLS scenarios while keeping the QoE of the users at acceptable levels, by analyzing the scalability limits of WebRTC media servers and using this knowledge to effectively interconnect media servers in order to distribute the load efficiently. Three research objectives were established: (i) to study and propose load testing strategies for WebRTC applications, (ii) to study QoE degradation in WebRTC media servers under high load, and (iii) to study scaling strategies for LLLS with WebRTC by interconnecting media servers. Non-browser-based emulation strategies, in particular kms-webrtc, reduce testing costs by up to 96.6% compared to browser-based approaches. QoE analysis under load shows distinct failure modes: Kurento and Pion degrade primarily under CPU saturation, while Mediasoup remains stable until round-trip time (RTT) exceeds approximately 0.2 s and jitter 0.04 s. Mediasoup supports up to six times more users before QoE degradation than Kurento and nearly twice as many as Pion. Regarding horizontal scalability, media server interconnection introduces negligible latency, allowing us to focus on optimizing server costs. The best presented scalability strategy, which optimizes session, publisher and viewer assignment and per-server capacity reservation, significantly outperforms alternatives in resource utilization and costs. The results confirm the initial hypothesis and provide practical guidelines, tools, and datasets for designing scalable WebRTC-based low-latency streaming platforms that scale to large audiences while maintaining acceptable QoE.
+  - kind: journal
+    anchor: quality-of-experience-under-huge-load-for-webrtc-applications-a-case-study-of-three-media-servers
+    title: "Quality of Experience Under Huge Load for WebRTC Applications: A Case Study of Three Media Servers"
+    url: https://doi.org/10.1109/ACCESS.2025.3589785
+    doi: 10.1109/ACCESS.2025.3589785
+    year: 2025
+    venue: IEEE Access
+    authors:
+      - name: Iván Chicano-Capelo
+        orcid: https://orcid.org/0000-0003-1857-9615
+      - name: Francisco Gortázar
+        orcid: https://orcid.org/0000-0002-2183-0869
+      - name: Micael Gallego
+        orcid: https://orcid.org/0000-0002-2875-7342
+    images:
+      - /assets/images/research/qoe-pion.png
+      - /assets/images/research/qoe-mediasoup.png
+    abstract: >-
+      Videoconference applications are becoming increasingly popular, and the demand for these applications is growing. The availability of a standard for building videoconference application on the web, the W3C WebRTC standard, boosted the development of such applications. With so many alternatives available, an impact on quality due to an overload of such applications might cause users to leave and choose another service instead. This makes stress testing mandatory in order to understand the limits of these videoconference solutions and how these limits impact the quality of experience (QoE) of the users. However, most testing tools are not designed to calculate QoE, which is essential for real-time videoconference applications, because QoE calculation is complex and a computationally intensive process. This paper focuses on how load impacts QoE for WebRTC applications and presents OpenVidu QoE and Load Testing Tool (OQLT), a load and stress testing tool for WebRTC applications which measures the QoE of users in videoconference applications. In this work, we make use of this tool to help researchers and practitioners understand the impact of server load on the QoE of users in WebRTC applications, by analyzing three different communication systems: Kurento, Mediasoup, and Pion. Our findings show that in two of the three media servers (Kurento and Pion), CPU alone is a good indicator of QoE degradation, whereas for Mediasoup, additional WebRTC metrics are needed, because under high CPU usage Mediasoup can still provide a good QoE to its users.
+  - kind: journal
+    anchor: cost-effective-load-testing-of-webrtc-applications
+    title: "Cost-effective load testing of WebRTC applications"
+    url: https://doi.org/10.1016/j.jss.2022.111439
+    doi: 10.1016/j.jss.2022.111439
+    year: 2022
+    venue: Journal of Systems and Software
+    authors:
+      - name: Francisco Gortázar
+        orcid: https://orcid.org/0000-0002-2183-0869
+      - name: Micael Gallego
+        orcid: https://orcid.org/0000-0002-2875-7342
+      - name: Michel Maes-Bermejo
+        orcid: https://orcid.org/0000-0002-8138-9702
+      - name: Iván Chicano-Capelo
+        orcid: https://orcid.org/0000-0003-1857-9615
+      - name: Carlos Santos
+    images:
+      - /assets/images/research/ovlt-arch.png
+      - /assets/images/research/ovlt-results.png
+    abstract: >-
+      Background: Video conference applications and systems implementing the WebRTC W3C standard are becoming more popular and demanded year after year, and load testing them is of paramount importance to ensure they can cope with demand. However, this is an expensive activity, usually involving browsers to emulate users.
+      Goal: to propose browser-less alternative strategies for load testing WebRTC services, and to study performance and costs of those strategies when compared with traditional ones.
+      Method: (a) Exploring the limits of existing and novel strategies for load testing WebRTC services from a single machine. (b) Comparing the common strategy of using browsers with the best of our proposed strategies in terms of cost in a load testing scenario.
+      Results: We observed that, using identical machines, our proposed strategies are able to emulate more users than traditional strategies. We also found a huge saving in expenditure for load testing, as our strategy suppose a saving of 96% with respect to usual browser-based strategies.
+      Conclusion: We provide details on scalability of different load testing strategies in terms of users emulated, as well as CPU and memory used. We could reduce the expenditure of load tests of WebRTC applications.
+  - kind: conference
+    anchor: quality-of-experience-driven-configuration-of-webrtc-services-through-automated-testing
+    title: "Quality-of-Experience driven configuration of WebRTC services through automated testing"
+    url: https://doi.org/10.1109/QRS51102.2020.00031
+    doi: 10.1109/QRS51102.2020.00031
+    year: 2020
+    venue: 2020 IEEE 20th International Conference on Software Quality, Reliability and Security (QRS)
+    authors:
+      - name: Antonia Bertolino
+        orcid: https://orcid.org/0000-0001-8749-1356
+      - name: Antonello Calabró
+        orcid: https://orcid.org/0000-0001-5502-303X
+      - name: Guglielmo De Angelis
+        orcid: https://orcid.org/0000-0002-1076-0076
+      - name: Francisco Gortázar
+        orcid: https://orcid.org/0000-0002-2183-0869
+      - name: Francesca Lonetti
+        orcid: https://orcid.org/0000-0002-4864-2219
+      - name: Michel Maes
+        orcid: https://orcid.org/0000-0002-8138-9702
+      - name: Guiomar Tuñón
+    abstract: >-
+      Quality of Experience (QoE) refers to the end users level of satisfaction with a real-time service, in particular in relation to its audio and video quality. Advances in WebRTC technology have favored the spread of multimedia services through use of any browser. Provision of adequate QoE in such services is of paramount importance. The assessment of QoE is costly and can be done only late in the service lifecycle. In this work we propose a simple approach for QoE-driven non-functional testing of WebRTC services that relies on the ElasTest open-source platform for end-to-end testing of large complex systems. We describe the ElasTest platform, the proposed approach and an experimental study. In this study, we compared qualitatively and quantitatively the effort required in the ElasTest supported scenario with respect to a "traditional" solution, showing great savings in terms of effort and time.
+  - kind: journal
+    anchor: a-survey-of-the-selenium-ecosystem
+    title: "A Survey of the Selenium Ecosystem"
+    url: https://doi.org/10.3390/electronics9071067
+    doi: 10.3390/electronics9071067
+    year: 2020
+    venue: Electronics
+    authors:
+      - name: Boni García
+        orcid: https://orcid.org/0000-0003-1808-8410
+      - name: Micael Gallego
+        orcid: https://orcid.org/0000-0002-2875-7342
+      - name: Francisco Gortázar
+        orcid: https://orcid.org/0000-0002-2183-0869
+      - name: Mario Munoz-Organero
+        orcid: https://orcid.org/0000-0003-4199-2002
+    images:
+      - /assets/images/research/selenium.png
+    abstract: >-
+      Selenium is often considered the de-facto standard framework for end-to-end web testing nowadays. It allows practitioners to drive web browsers (such as Chrome, Firefox, Edge, or Opera) in an automated fashion using different language bindings (such as Java, Python, or JavaScript, among others). The term ecosystem, referring to the open-source software domain, includes various components, tools, and other interrelated elements sharing the same technological background. This article presents a descriptive survey aimed to understand how the community uses Selenium and its ecosystem. This survey is structured in seven categories: Selenium foundations, test development, system under test, test infrastructure, other frameworks, community, and personal experience. In light of the current state of Selenium, we analyze future challenges and opportunities around it.
+  - kind: journal
+    anchor: assessment-of-qoe-for-video-and-audio-in-webrtc-applications-using-full-reference-models
+    title: "Assessment of QoE for Video and Audio in WebRTC Applications Using Full-Reference Models"
+    url: https://doi.org/10.3390/electronics9030462
+    doi: 10.3390/electronics9030462
+    year: 2020
+    venue: Electronics
+    authors:
+      - name: Boni García
+        orcid: https://orcid.org/0000-0003-1808-8410
+      - name: Micael Gallego
+        orcid: https://orcid.org/0000-0002-2875-7342
+      - name: Francisco Gortázar
+        orcid: https://orcid.org/0000-0002-2183-0869
+      - name: Andrew Hines
+        orcid: https://orcid.org/0000-0001-9636-2556
+    images:
+      - /assets/images/research/qoe-assessment.png
+    abstract: >-
+      WebRTC is a set of standard technologies that allows exchanging video and audio in real time on the Web. As with other media-related applications, the user-perceived audiovisual quality can be estimated using Quality of Experience (QoE) measurements. This paper analyses the behavior of different objective Full-Reference (FR) models for video and audio in WebRTC applications. FR models calculate the video and audio quality by comparing some original media reference with the degraded signal. To compute these models, we have created an open-source benchmark in which different types of reference media inputs are sent browser to browser while simulating different kinds of network conditions in terms of packet loss and jitter. Then, we use different existing FR metrics for video (VMAF, VIFp, SSIM, MS-SSIM, PSNR, PSNR-HVS, and PSNR-HVS-M) and audio (PESQ, ViSQOL, and POLQA) recordings together with their references. Moreover, we use the same recordings to carry out a subjective analysis in which real users rate the video and audio quality using a Mean Opinion Score (MOS). Finally, we calculate the correlations between the objective and subjective results to find the objective models that better correspond with the subjective outcome. We find that some of the studied objective models, such as VMAF, VIFp, and POLQA, show a strong correlation with the subjective results in packet loss scenarios.
+  - kind: journal
+    anchor: understanding-and-estimating-quality-of-experience-in-webrtc-applications
+    title: "Understanding and estimating quality of experience in WebRTC applications"
+    url: https://doi.org/10.1007/s00607-018-0669-7
+    doi: 10.1007/s00607-018-0669-7
+    year: 2019
+    venue: Computing
+    authors:
+      - name: Boni García
+        orcid: https://orcid.org/0000-0003-1808-8410
+      - name: Micael Gallego
+        orcid: https://orcid.org/0000-0002-2875-7342
+      - name: Francisco Gortázar
+        orcid: https://orcid.org/0000-0002-2183-0869
+      - name: Antonia Bertolino
+        orcid: https://orcid.org/0000-0001-8749-1356
+    images:
+      - /assets/images/research/qos-qoe.png
+    abstract: >-
+      WebRTC comprises a set of technologies and standards that provide real-time communication with web browsers, simplifying the embedding of voice and video communication in web applications and mobile devices. The perceived quality of WebRTC communication can be measured using quality of experience (QoE) indicators. QoE is defined as the degree of delight or annoyance of the user with an application or service. This paper is focused on the QoE assessment of WebRTC-based applications and its contribution is threefold. First, an analysis of how WebRTC topologies affect the quality perceived by users is provided. Second, a group of Key Performance Indicators for estimating the QoE of WebRTC users is proposed. Finally, a systematic survey of the literature on QoE assessment in the WebRTC arena is presented.
+  - kind: journal
+    anchor: practical-evaluation-of-vmaf-perceptual-video-quality-for-webrtc-applications
+    title: "Practical Evaluation of VMAF Perceptual Video Quality for WebRTC Applications"
+    url: https://doi.org/10.3390/electronics8080854
+    doi: 10.3390/electronics8080854
+    year: 2019
+    venue: Electronics
+    authors:
+      - name: Boni García
+        orcid: https://orcid.org/0000-0003-1808-8410
+      - name: Luis López-Fernández
+      - name: Francisco Gortázar
+        orcid: https://orcid.org/0000-0002-2183-0869
+      - name: Micael Gallego
+        orcid: https://orcid.org/0000-0002-2875-7342
+    images:
+      - /assets/images/research/qoe-session.png
+      - /assets/images/research/webrtc-qoe-vs-packet-loss.png
+    abstract: >-
+      WebRTC is the umbrella term for several emergent technologies aimed to exchange real-time media in the Web. Like other media-related services, the perceived quality of WebRTC communication can be measured using Quality of Experience (QoE) indicators. QoE assessment methods can be classified as subjective (users' evaluation scores) or objective (models computed as a function of different parameters). In this paper, we focus on VMAF (Video Multi-method Assessment Fusion), which is an emergent full-reference objective video quality assessment model developed by Netflix. VMAF is typically used to assess video streaming services. This paper evaluates the use of VMAF in a different type of application: WebRTC. To that aim, we present a practical use case built on the top of well-known open source technologies, such as JUnit, Selenium, Docker, and FFmpeg. In addition to VMAF, we also calculate other objective QoE video metrics such as Visual Information Fidelity in the pixel domain (VIFp), Structural Similarity (SSIM), or Peak Signal-to-Noise Ratio (PSNR) applied to a WebRTC communication in different network conditions in terms of packet loss. Finally, we compare these objective results with a subjective evaluation using a Mean Opinion Score (MOS) scale to the same WebRTC streams. As a result, we found a strong correlation of the subjective video quality perceived in WebRTC video calls with the objective results computed with VMAF and VIFp in comparison with SSIM and PSNR and their variants.
+  - kind: conference
+    anchor: nubomedia-the-first-open-source-webrtc-paas
+    title: "NUBOMEDIA: The First Open Source WebRTC PaaS"
+    url: https://doi.org/10.1145/3123266.3129392
+    doi: 10.1145/3123266.3129392
+    year: 2017
+    venue: Proceedings of the 25th ACM International Conference on Multimedia (MM '17)
+    authors:
+      - name: Boni García
+        orcid: https://orcid.org/0000-0003-1808-8410
+      - name: Luis López
+      - name: Francisco Gortázar
+        orcid: https://orcid.org/0000-0002-2183-0869
+      - name: Micael Gallego
+        orcid: https://orcid.org/0000-0002-2875-7342
+      - name: Giuseppe Antonio Carella
+    abstract: >-
+      In this paper, we introduce NUBOMEDIA, an open source elastic cloud Platform as a Service (PaaS) specifically designed for real-time interactive multimedia and WebRTC services. NUBOMEDIA exposes its capabilities through simple Application Programming Interfaces (APIs), making possible to deploy and execute developers' applications. To that aim, NUBOMEDIA combines the simplicity and ease of development of API services with the flexibility of PaaS infrastructures. Once an application is implemented, developers just need to deploy it on top of NUBOMEDIA providing elasticity as a service and reliable communication.
+  - kind: journal
+    anchor: kurento-the-swiss-army-knife-of-webrtc-media-servers
+    title: "Kurento: The Swiss Army Knife of WebRTC Media Servers"
+    url: https://doi.org/10.1109/MCOMSTD.2017.1700006
+    doi: 10.1109/MCOMSTD.2017.1700006
+    year: 2017
+    venue: IEEE Communications Standards Magazine
+    authors:
+      - name: Boni García
+        orcid: https://orcid.org/0000-0003-1808-8410
+      - name: Luis López
+      - name: Micael Gallego
+        orcid: https://orcid.org/0000-0002-2875-7342
+      - name: Francisco Gortázar
+        orcid: https://orcid.org/0000-0002-2183-0869
+    abstract: >-
+      In this article we introduce Kurento, an open source WebRTC media server and a set of client APIs intended to simplify the development of applications with rich media capabilities for the Web and smartphone platforms. Kurento features include group communications, transcoding, recording, mixing, broadcasting and routing of audiovisual flows, but also provides advanced media processing capabilities such as computer vision and augmented reality. It is based on a modular architecture, which makes it possible for developers to extend and customize its native capabilities with third-party media processing algorithms. Thanks to all of this, Kurento can be a powerful tool for Web developers who may find natural programming with its Java and JavaScript APIs following the traditional three-tiered Web development model.
+  - kind: journal
+    anchor: webrtc-testing-challenges-and-practical-solutions
+    title: "WebRTC Testing: Challenges and Practical Solutions"
+    url: https://doi.org/10.1109/MCOMSTD.2017.1700005
+    doi: 10.1109/MCOMSTD.2017.1700005
+    year: 2017
+    venue: IEEE Communications Standards Magazine
+    authors:
+      - name: Boni García
+        orcid: https://orcid.org/0000-0003-1808-8410
+      - name: Francisco Gortázar
+        orcid: https://orcid.org/0000-0002-2183-0869
+      - name: Luis López
+      - name: Micael Gallego
+        orcid: https://orcid.org/0000-0002-2875-7342
+      - name: Miguel Paris
+    abstract: >-
+      WebRTC comprises a set of novel technologies and standards that provide Real-Time Communication on Web browsers. WebRTC makes simple the embedding of voice and video communications in all types of applications. However, releasing those applications to production is still very challenging due to the complexity of their testing. Validating a WebRTC service requires assessing many functional and non-functional properties on large, complex, distributed and heterogeneous systems that spawn across client devices, networks and cloud infrastructures. In this article, we present a novel methodology and an associated tool for doing it at scale and in an automated way. Our strategy is based on a blackbox end-to-end approach through which we use an automated containerized cloud environment for instrumenting Web browser clients, which benchmark the SUT (system under test), and fake clients, that load it. Through these benchmarks, we obtain, in a reliable and statistically significant way, both network-dependent QoS (Quality of Service) metrics and media-dependent QoE (Quality of Experience) indicators. To finish, we illustrate our experiences using such tool and methodology in the context of the Kurento open source software project and conclude that they are suitable for validating large and complex WebRTC systems at scale.
+  - kind: journal
+    anchor: designing-and-evaluating-the-usability-of-an-api-for-real-time-multimedia-services-in-the-internet
+    title: "Designing and evaluating the usability of an API for real-time multimedia services in the Internet"
+    url: https://doi.org/10.1007/s11042-016-3729-z
+    doi: 10.1007/s11042-016-3729-z
+    year: 2017
+    venue: Multimedia Tools and Applications
+    authors:
+      - name: Luis López-Fernández
+      - name: Boni García
+        orcid: https://orcid.org/0000-0003-1808-8410
+      - name: Micael Gallego
+        orcid: https://orcid.org/0000-0002-2875-7342
+      - name: Francisco Gortázar
+        orcid: https://orcid.org/0000-0002-2183-0869
+    images:
+      - /assets/images/research/kurento-api.png
+      - /assets/images/research/api-eval.png
+    abstract: >-
+      In the last few years, multimedia technologies in general, and Real-Time multimedia Communications (RTC) in particular, are becoming mainstream among WWW and smartphone developers, who have an increasing interest in richer media capabilities for creating their applications. The engineering literature proposing novel algorithms, protocols and architectures for managing and processing multimedia information is currently overwhelming. However, most of these results do not arrive to applications due to the lack of simple and usable APIs. In this paper we try to contribute to fill this gap by proposing the RTC Media API: a novel type of API designed with the aim of making simple for developers the use of latest trends in RTC multimedia including WebRTC, Video Content Analysis or Augmented Reality. We provide a specification of such API and discuss how it satisfies a set of design requirements. After that, we describe an implementation of such an API that has been created in the context of the Kurento open source software project, and present a study evaluating the API usability performed in a group of more than 40 professional developers distributed worldwide. In the light of the obtained results, we conclude that the usability of the API is adequate across the main development activities, with an average usability score of 3.39 over 5 in a Likert scale.
+  - kind: conference
+    anchor: webrtc-testing-state-of-the-art
+    title: "WebRTC Testing: State of the Art"
+    url: https://doi.org/10.5220/0006442003630371
+    doi: 10.5220/0006442003630371
+    year: 2017
+    venue: Proceedings of the 12th International Conference on Software Technologies (ICSOFT)
+    authors:
+      - name: Boni García
+        orcid: https://orcid.org/0000-0003-1808-8410
+      - name: Micael Gallego
+        orcid: https://orcid.org/0000-0002-2875-7342
+      - name: Francisco Gortázar
+        orcid: https://orcid.org/0000-0002-2183-0869
+      - name: Eduardo Jiménez
+    abstract: >-
+      WebRTC is the umbrella term for a number of emerging technologies that extends the web browsing model to exchange real-time media (Voice over IP, VoIP) with other browsers. The mechanisms to provide quality assurance for WebRTC are key to release this kind of applications to production environments. Nevertheless, testing WebRTC based application, consistently automated fashion is a challenging problem. The aim of this piece of research is to provide a comprehensive summary of the current trends in the domain of WebRTC testing. For the sake of completeness, we have carried out this survey by aggregating the results from three different sources of information: i) Scientific and academia research papers; ii) WebRTC testing tools (both commercial and open source); iii) "Grey literature", that is, materials produced by organizations outside of the traditional commercial or academic publishing and distribution channels.
+  - kind: conference
+    anchor: analysis-of-video-quality-and-end-to-end-latency-in-webrtc
+    title: "Analysis of Video Quality and End-to-End Latency in WebRTC"
+    url: https://doi.org/10.1109/GLOCOMW.2016.7848838
+    doi: 10.1109/GLOCOMW.2016.7848838
+    year: 2016
+    venue: 2016 IEEE Globecom Workshops (GC Wkshps)
+    authors:
+      - name: Boni García
+        orcid: https://orcid.org/0000-0003-1808-8410
+      - name: Luis López-Fernández
+      - name: Francisco Gortázar
+        orcid: https://orcid.org/0000-0002-2183-0869
+      - name: Micael Gallego
+        orcid: https://orcid.org/0000-0002-2875-7342
+    abstract: >-
+      WebRTC is a set of emerging technologies that extends the web browsing model to exchange real-time media with other browsers. Despite the fact that WebRTC is still in under development, it is gaining the attention of practitioners quickly. For that reason, the mechanisms to provide quality assurance for WebRTC are key to release these kind of applications to production environments. Nevertheless, testing WebRTC based application, consistently automated fashion is a challenging problem. This article presents the Kurento Testing Framework (KTF), a piece of software aimed to simplify the evaluation activities for WebRTC applications and services. It provides advanced features to carry out complete assessment of WebRTC applications in terms of functionality and quality-of-experience.
+  - kind: conference
+    anchor: kurento-the-webrtc-modular-media-server
+    title: "Kurento: The WebRTC Modular Media Server"
+    url: https://doi.org/10.1145/2964284.2973798
+    doi: 10.1145/2964284.2973798
+    year: 2016
+    venue: Proceedings of the 24th ACM International Conference on Multimedia (MM '16)
+    authors:
+      - name: Luis López
+      - name: Miguel París
+      - name: Santiago Carot
+      - name: Boni García
+        orcid: https://orcid.org/0000-0003-1808-8410
+      - name: Micael Gallego
+        orcid: https://orcid.org/0000-0002-2875-7342
+      - name: Francisco Gortázar
+        orcid: https://orcid.org/0000-0002-2183-0869
+      - name: Raul Benítez
+      - name: Jose A. Santos
+      - name: David Fernández
+      - name: Radu Tom Vlad
+      - name: Iván Gracia
+      - name: Francisco Javier López
+    abstract: >-
+      In this paper we introduce Kurento Media Server: an open source WebRTC Media Server providing a toolbox of capabilities which include group communications, recording, routing, transcoding and mixing. Kurento supports a large number of media protocols such as WebRTC, plain RTP, RTSP or HTTP and bunch of codecs including VP8, VP9, H.264, H.263, OPUS, Speex, PCM or AMR. Kurento Media Server is based on a modular architecture, which makes it possible for developers to extend and customize its native capabilities with advanced media processing features such as computer vision, augmented reality or speech analysis. Kurento is ideal for WWW developers who find natural programming with its Java and JavaScript APIs following the traditional three tiered WWW development model.
+  - kind: conference
+    anchor: testing-framework-for-webrtc-services
+    title: "Testing Framework for WebRTC Services"
+    url: https://dl.acm.org/doi/10.5555/3021385.3021393
+    year: 2016
+    venue: Proceedings of the 9th EAI International Conference on Mobile Multimedia Communications (MobiMedia)
+    authors:
+      - name: Boni García
+        orcid: https://orcid.org/0000-0003-1808-8410
+      - name: Luis López-Fernández
+      - name: Micael Gallego
+        orcid: https://orcid.org/0000-0002-2875-7342
+      - name: Francisco Gortázar
+        orcid: https://orcid.org/0000-0002-2183-0869
+    abstract: >-
+      WebRTC is the umbrella term for several emergent technologies aimed to exchange real-time media in the Web. WebRTC is gaining the attention of practitioners quickly, and therefore the mechanisms to provide quality assurance for WebRTC services are becoming more and more demanded. WebRTC has been conceived as a peer-to-peer architecture where browsers can directly communicate. This model can be extended using a media server to provide extra features such as group communications, media recording, and so on. In this context, the open source initiative kurento.org provides a WebRTC media server and a set of APIs aimed to simplify the development of advanced WebRTC applications. Among these APIs, Kurento provides a high level testing infrastructure to assess WebRTC services in terms of functionality, performance, and quality-of-experience. This paper presents a detailed description of the testing services provided by this framework.
+  - kind: conference
+    anchor: nubomedia-an-elastic-paas-enabling-the-convergence-of-real-time-and-big-data-multimedia
+    title: "NUBOMEDIA: An Elastic PaaS Enabling the Convergence of Real-Time and Big Data Multimedia"
+    url: https://doi.org/10.1109/SmartCloud.2016.11
+    doi: 10.1109/SmartCloud.2016.11
+    year: 2016
+    venue: 2016 IEEE International Conference on Smart Cloud (SmartCloud)
+    authors:
+      - name: Boni García
+        orcid: https://orcid.org/0000-0003-1808-8410
+      - name: Micael Gallego
+        orcid: https://orcid.org/0000-0002-2875-7342
+      - name: Luis López
+      - name: Giuseppe Antonio Carella
+      - name: Alice Cheambe
+    abstract: >-
+      The increasing acceptance of Network Function Virtualization (NFV) and Software Defined Networks (SDN) paradigms is enabling the creation of cloud technologies combining Real-Time multimedia Communications (RTC) and multimedia processing for big data. Although many vendors already provide solutions in these areas, none of them comprises a single platform for end-to-end service provisioning and deployment addressing all the complexities of combining RTC and media processing. As a result, developing such types of applications is still extremely complex. Following this, we present NUBOMEDIA, an open-source platform enabling developers to create and deploy RTC applications with advanced media processing capabilities. For this, NUBOMEDIA introduces the concept of Media Pipeline: chains of interconnected media processing elements. At deployment time, NUBOMEDIA follows a Platform as a Service (PaaS) scheme, which abstracts for developers most of the complex infrastructure-related tasks such as provisioning, scaling or QoS and network management. In this paper we present the NUBOMEDIA architecture, which bases on ETSI NFV recommendations, and introduce the main interfaces and capabilities it exposes to developers.
+  - kind: conference
+    anchor: design-and-implementation-of-a-high-performant-paas-platform-for-creating-novel-real-time-communication-paradigms
+    title: "Design and Implementation of a High Performant PaaS Platform for Creating Novel Real-Time Communication Paradigms"
+    url: https://dl.ifip.org/db/conf/icin/icin2016/1570230514.pdf
+    year: 2016
+    venue: 19th International Conference on Innovations in Clouds, Internet and Networks (ICIN)
+    authors:
+      - name: Alice Cheambe
+      - name: Flavio Murgia
+      - name: Pasquale Maiorano Picone
+      - name: Boni García
+        orcid: https://orcid.org/0000-0003-1808-8410
+      - name: Micael Gallego
+        orcid: https://orcid.org/0000-0002-2875-7342
+      - name: Giuseppe Antonio Carella
+      - name: Lorenzo Tomasini
+      - name: Alin Calinciuc
+      - name: Cristian Spoiala
+    abstract: >-
+      This paper presents the design and implementation of a Real Time Communication and multimedia processing architecture that uses emerging Network Function Virtualization (NFV) and Software Defined Networks (SDN) to provide enabling cloud technologies. This is work done within the EU project NUBOMEDIA. The main objective of the NUBOMEDIA project is to address the complexity usually involved in providing such a platform, thereby providing a single platform for end-to-end service provisioning, deployment and availability of services. To validate the platform, within the project use case implementations from eHealth, IPTV, augmented reality and collaborative e-Learning are being developed and tested. For such services, a Platform-as-a-Service (PaaS) strategy is proposed which hides the complexity of the infrastructure thereby abstracting services for provisioning, scaling, QoS and network management. This paper highlights the NUBOMEDIA architecture and describe the application deployment procedure for developers.
+  - kind: journal
+    anchor: authentication-authorization-and-accounting-in-webrtc-paas-infrastructures-the-case-of-kurento
+    title: "Authentication, Authorization, and Accounting in WebRTC PaaS Infrastructures: The Case of Kurento"
+    url: https://doi.org/10.1109/MIC.2014.102
+    doi: 10.1109/MIC.2014.102
+    year: 2014
+    venue: IEEE Internet Computing
+    authors:
+      - name: Luis López-Fernández
+      - name: Micael Gallego
+        orcid: https://orcid.org/0000-0002-2875-7342
+      - name: Boni García
+        orcid: https://orcid.org/0000-0003-1808-8410
+      - name: David Fernández-López
+      - name: Francisco Javier López
+    abstract: >-
+      WebRTC server infrastructures are useful for creating rich real-time communication (RTC) applications. Developers commonly use them for accessing capabilities such as group communications, archiving, and transcoding. Details on how to implement and use such infrastructures securely are of increasing interest to the engineering community. Kurento is an open source project that provides a WebRTC media server and a platform as a service cloud built on top of it. The authors present the Kurento API and analyze different security models for it, investigating the suitability of using simple access control lists (ACLs) and capability-based security schemes to provide authorization. Using minimal implementation, they discuss the advantages and drawbacks of each scheme and conclude that, for the proposed schemes, ACLs are less scalable but provide more granularity.
 ---
 
 <style>


### PR DESCRIPTION
# JSON-LD structured data on openvidu.io

Reference for the schema.org JSON-LD emitted by the website, as implemented in the
`json-ld-proposal` branch of [openvidu/openvidu.io](https://github.com/openvidu/openvidu.io).

**Implementation:** a single Jinja partial, `docs/overrides/partials/json-ld.html`,
included from the `extrahead` block of `docs/overrides/main.html`. It decides what to
emit from the page's source path (`page.file.src_uri`) or its frontmatter. Every page
that emits JSON-LD does so as one `<script type="application/ld+json">` block in the
`<head>`, containing a `@graph` that always starts with the shared **Organization**
node. All other pages emit nothing.

**URL policy:** all URLs use the canonical form. Product pages are hardcoded to
`/latest/` (never a pinned version) so ranking signals consolidate on the canonical
URL. Non-versioned pages (blog, research) use `page.canonical_url`, whose version
segment is stripped at deploy time by `custom-versioning/push-new-version.sh`.

---

## Shared node: Organization (on every emitting page)

| Property | Value |
|---|---|
| `@type` / `@id` | `Organization` / `https://openvidu.io/#organization` |
| `name` / `url` | OpenVidu / `https://openvidu.io/` |
| `description` | Positioning statement: self-hosted videoconferencing and custom WebRTC solutions (Meet + Platform) |
| `logo` | `ImageObject` → `https://openvidu.io/assets/images/openvidu_vert_white_bg_trans_cropped2.png` |
| `sameAs` | GitHub, X, Medium, YouTube profiles |
| `contactPoint` | `customer support` → `https://openvidu.io/support/` |

Other nodes reference it via `{"@id": "https://openvidu.io/#organization"}` as
`publisher`/`author`, so every page's graph is self-contained.

## Homepage — `https://openvidu.io/` (`index.md`)

`@graph`: **Organization + WebSite + SoftwareApplication ×2**

- **WebSite** (`@id: /#website`): name, url, `inLanguage: en`, publisher → Organization.
- Both product `SoftwareApplication` nodes (identical to the ones below), since the
  homepage presents both products and is the page most likely to earn brand rich results.

## OpenVidu Meet product page — `/latest/meet/` (`meet/index.md`)

`@graph`: **Organization + SoftwareApplication**

| Property | Value |
|---|---|
| `@id` / `url` | `https://openvidu.io/latest/meet/#software` / `https://openvidu.io/latest/meet/` |
| `name` | OpenVidu Meet |
| `description` | Ready-to-use, self-hosted videoconferencing: rooms, recordings, embedding with minimal code |
| `applicationCategory` | `CommunicationApplication` |
| `operatingSystem` | Linux (self-hosted server), any modern web browser (client) |
| `offers` | `Offer`, price 0 EUR (COMMUNITY edition free; PRO described), url → `/pricing/` |
| `author` / `publisher` | → Organization |

## OpenVidu Platform product page — `/latest/docs/` (`docs/index.md`)

`@graph`: **Organization + SoftwareApplication**

Same shape as Meet, with:

| Property | Value |
|---|---|
| `@id` / `url` | `https://openvidu.io/latest/docs/#software` / `https://openvidu.io/latest/docs/` |
| `name` | OpenVidu Platform |
| `description` | Programmable platform with client/server SDKs for custom self-hosted WebRTC apps (low latency, scalability, fault tolerance) |
| `applicationCategory` | `DeveloperApplication` |
| `operatingSystem` | Linux (self-hosted server); client SDKs for browsers, Android and iOS |

## Blog index — `/blog/` (`blog/index.md`)

`@graph`: **Organization + Blog**

- **Blog** (`@id: /blog/#blog`): name "OpenVidu Blog", url, description, `inLanguage`,
  publisher → Organization.
- `blogPost`: one compact `BlogPosting` per post in the view (headline, canonical URL,
  `datePublished`), built from `page.posts` — stays in sync automatically as posts are
  published. Currently lists all 10 posts.

## Blog posts — `/blog/YYYY/MM/DD/<slug>/` (`blog/posts/*.md`)

`@graph`: **Organization + BlogPosting**

| Property | Source |
|---|---|
| `@id` / `url` / `mainEntityOfPage` | `page.canonical_url` |
| `headline` | Post H1 (`page.title`) |
| `description` | `description:` frontmatter (present on all posts) |
| `datePublished` / `dateModified` | Blog plugin dates (`date:` frontmatter; `updated` if set, else same as published) |
| `image` | Optional `image:` frontmatter (absolute or root-relative); omitted if absent |
| `author` | `Person` per author from `.authors.yml` (name + about-us URL); falls back to Organization if no authors |
| `publisher` | → Organization |
| `inLanguage` | `en` |

## Research page — `/research/` (`research.md`)

`@graph`: **Organization + 19 publication nodes**

Data source: a `publications:` list in `research.md`'s frontmatter (title, authors with
ORCID, venue, DOI, year, figures, full abstract) — kept next to the page content it
mirrors. The partial emits these for *any* page declaring a `publications` list.

Per publication:

| Property | Value |
|---|---|
| `@type` | `ScholarlyArticle` (18 papers) or `Thesis` (the 2026 PhD thesis) |
| `@id` | `https://openvidu.io/research/#<heading-anchor>` — verified to match the rendered `<h2 id>` linked from the index table |
| `headline` / `url` | Title / external landing page (doi.org, Dialnet, ACM DL, IFIP PDF) |
| `mainEntityOfPage` | `https://openvidu.io/research/` |
| `datePublished` | Year |
| `identifier` / `sameAs` | DOI as `PropertyValue` (propertyID `DOI`) + `https://doi.org/<doi>` — on the 16 publications that have a DOI |
| `isPartOf` | Journal as `Periodical`, or conference proceedings as `CreativeWork` |
| `sourceOrganization` | (Thesis only) `CollegeOrUniversity` — Universidad Rey Juan Carlos |
| `author` | `Person` nodes; ORCID URL as `@id` + `sameAs` where available (11 distinct ORCID-linked researchers) |
| `contributor` | (Thesis only) the two supervisors |
| `image` | Absolute URLs of the article figures shown on the page (8 publications) |
| `abstract` | Full abstract text |
| `inLanguage` | `en` |

---

## Maintenance notes

- **New blog post:** nothing to do — BlogPosting and the Blog index list are generated
  from the post's frontmatter and `.authors.yml`.
- **New research publication:** add the page content **and** a matching entry in the
  `publications:` frontmatter list of `research.md`; `anchor` must equal the heading id.
- **New author:** add to `docs/blog/.authors.yml`; use an absolute `https://openvidu.io/about-us/#...` URL so it's included in JSON-LD (relative URLs are skipped).
- **Renamed/new products or social profiles:** update the macros at the top of
  `docs/overrides/partials/json-ld.html`.
- **Validation:** serve locally (`docker run --rm -p 9100:8000 -v ${PWD}:/docs squidfunk/mkdocs-material`)
  and check pages in Google's Rich Results Test / schema.org validator. Local URLs show
  `http://0.0.0.0:8000/...` because `mkdocs serve` overrides `site_url`; real builds emit
  `https://openvidu.io/...`.