### PR TITLE
Landing hero cta

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -43,7 +43,7 @@ tags:
         </ul>
       </div>
       <div class="product-footer">
-        <a href="meet/" class="product-button md-button md-button--primary primary">Get Started</a>
+        <a href="meet/" class="product-button md-button md-button--primary primary">Deploy Meet in minutes</a>
       </div>
     </div>
     <div class="product-card openvidu-platform">
@@ -67,7 +67,7 @@ tags:
         </ul>
       </div>
       <div class="product-footer">
-        <a href="docs/" class="product-button md-button md-button--primary primary">Get Started</a>
+        <a href="docs/" class="product-button md-button md-button--primary primary">Start building with the SDKs</a>
       </div>
     </div>
   </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -83,7 +83,7 @@ tags:
 
 <div class="second-slogan wow animated animatedFadeInUp fadeInUp">
   <h2 id="get-started">
-    Self-host a production-ready live-video platform with advanced capabilities typically reserved for pricy SaaS solutions
+    Self-host a production-ready live-video platform with advanced capabilities typically reserved for expensive SaaS solutions
   </h2>
 </div>
 
@@ -226,7 +226,7 @@ tags:
 <hr style="margin: 7em 0 3.5em 0;">
 
 <div class="second-slogan wow animated animatedFadeInUp fadeInUp" style="margin: 6em 0; text-align: center">
-  <h2 style="margin-bottom: 1em">Build, deploy on-premises and scale your videoconferencing or live streaming app with ease. Contact us if you need it : we are here to help!</h2>
+  <h2 style="margin-bottom: 1em">Build, deploy on-premises and scale your videoconferencing or live streaming app with ease. Need a hand? We are here to help.</h2>
   <div class="home-buttons">
     <a href="/support/" class="md-button home-secondary-button">Talk to an expert</a>
   </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -215,6 +215,14 @@ tags:
 </div>
 </div>
 
+<div class="home-buttons wow animated animatedFadeInUp fadeInUp" style="margin-top: 3em;">
+  <a title="Get started with OpenVidu Meet" class="md-button md-button--primary home-meet-button" href="meet/">Deploy Meet in minutes</a>
+  <a title="Build with OpenVidu Platform SDKs" class="md-button home-platform-button" href="docs/">Start building with the SDKs</a>
+</div>
+<p class="home-under-cta">
+  Not sure which fits? <a href="/openvidu-meet-vs-openvidu-platform/">Compare Meet vs Platform</a>
+</p>
+
 <hr style="margin: 7em 0 3.5em 0;">
 
 <div class="second-slogan wow animated animatedFadeInUp fadeInUp" style="margin: 6em 0; text-align: center">

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,7 +59,7 @@ tags:
           For developers that need complete freedom to build their real-time application using SDKs and self-host a production-ready solution.
         </p>
         <ul class="product-features">
-          <li>Programmable client and server SDKs for all languages compatible with <a href="https://docs.livekit.io/reference/" target="_blank">LiveKit</a></li>
+          <li>Programmable client and server SDKs for all languages, LiveKit-compatible</li>
           <li>Build your custom UI from scratch with total freedom</li>
           <li>Low level control of real time media: codecs, protocols, bitrates...</li>
           <li>Precise control of recording and streaming with custom layouts</li>

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -31,7 +31,7 @@
   <p class="home-description">
     Launch <strong>OpenVidu Meet</strong> on your own servers in minutes — or
     build any real-time app with <strong>OpenVidu Platform</strong>'s WebRTC
-    SDKs. Open source, ultra-low latency, and scalable to thousands of
+    SDKs.<br>Open source, ultra-low latency, and scalable to thousands of
     participants, with your users' data on your infrastructure.
   </p>
   <div class="home-buttons">

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -63,6 +63,10 @@
       Start a tour
     </a>
   </p>
+  <!-- Single wrapper: the hero is a space-around flex column, so as separate
+       flex items these two lines would get leftover viewport height
+       distributed between them regardless of their margins. -->
+  <div class="home-trust-block">
   <p class="home-trust-line">
     ⭐ Free &amp; open source<span class="home-sep">·</span>Apache 2.0<span
       id="github-stars-segment"
@@ -88,6 +92,7 @@
       >·</span
     >🛠 Upstream contributors to LiveKit, mediasoup &amp; Kurento
   </p>
+  </div>
   <script>
     // Live counters for the hero trust line (GitHub stars, Docker Hub pulls).
     // Each value is cached per session, and its segment stays hidden if the

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -64,14 +64,16 @@
     </a>
   </p>
   <p class="home-trust-line">
-    ⭐ Free &amp; open source · Apache 2.0<span id="github-stars-segment" hidden>
-      ·
-      <a href="https://github.com/OpenVidu/openvidu" target="_blank"
+    ⭐ Free &amp; open source<span class="home-sep">·</span>Apache 2.0<span
+      id="github-stars-segment"
+      hidden
+      ><span class="home-sep">·</span
+      ><a href="https://github.com/OpenVidu/openvidu" target="_blank"
         >★ <span id="github-stars-count"></span> on GitHub</a
       ></span
-    ><span id="dockerhub-pulls-segment" hidden>
-      ·
-      <a
+    ><span id="dockerhub-pulls-segment" hidden
+      ><span class="home-sep">·</span
+      ><a
         href="https://hub.docker.com/r/openvidu/openvidu-server"
         target="_blank"
         >🐳 <span id="dockerhub-pulls-count"></span> Docker pulls</a
@@ -80,9 +82,11 @@
   </p>
   <p class="home-trust-line home-credentials-line">
     🔬
-    <a href="/research/">19 peer-reviewed publications · 500+ citations</a>
-    · 🌐 12+ years building WebRTC · 🛠 Upstream contributors to LiveKit,
-    mediasoup &amp; Kurento
+    <a href="/research/">19 peer-reviewed publications · 500+ citations</a
+    ><span class="home-sep">·</span>🌐 12+ years building WebRTC<span
+      class="home-sep"
+      >·</span
+    >🛠 Upstream contributors to LiveKit, mediasoup &amp; Kurento
   </p>
   <script>
     // Live counters for the hero trust line (GitHub stars, Docker Hub pulls).

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -64,7 +64,7 @@
     </a>
   </p>
   <p class="home-trust-line">
-    ⭐ Open source · Apache 2.0<span id="github-stars-segment" hidden>
+    ⭐ Free &amp; open source · Apache 2.0<span id="github-stars-segment" hidden>
       ·
       <a href="https://github.com/OpenVidu/openvidu" target="_blank"
         >★ <span id="github-stars-count"></span> on GitHub</a

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -69,39 +69,89 @@
       <a href="https://github.com/OpenVidu/openvidu" target="_blank"
         >★ <span id="github-stars-count"></span> on GitHub</a
       ></span
+    ><span id="dockerhub-pulls-segment" hidden>
+      ·
+      <a
+        href="https://hub.docker.com/r/openvidu/openvidu-server"
+        target="_blank"
+        >🐳 <span id="dockerhub-pulls-count"></span> Docker pulls</a
+      ></span
     >
   </p>
   <script>
-    // Live GitHub star count for the hero trust line. Cached per session;
-    // the segment stays hidden if the API is unavailable (rate limit,
-    // offline), so the line gracefully shortens to "Open source · Apache 2.0".
+    // Live counters for the hero trust line (GitHub stars, Docker Hub pulls).
+    // Each value is cached per session, and its segment stays hidden if the
+    // source is unavailable (rate limit, offline), so the line gracefully
+    // shortens to "Open source · Apache 2.0".
     (function () {
-      var countEl = document.getElementById("github-stars-count");
-      var segmentEl = document.getElementById("github-stars-segment");
-      if (!countEl || !segmentEl) return;
-      function render(stars) {
-        var n = parseInt(stars, 10);
-        if (!n) return;
-        countEl.textContent =
-          n >= 1000 ? (n / 1000).toFixed(1).replace(/\.0$/, "") + "k" : n;
-        segmentEl.hidden = false;
+      function setupCounter(countId, segmentId, cacheKey, fetchValue) {
+        var countEl = document.getElementById(countId);
+        var segmentEl = document.getElementById(segmentId);
+        if (!countEl || !segmentEl) return;
+        function render(value) {
+          if (!value) return;
+          countEl.textContent = value;
+          segmentEl.hidden = false;
+        }
+        var cached = sessionStorage.getItem(cacheKey);
+        if (cached) {
+          render(cached);
+          return;
+        }
+        fetchValue()
+          .then(function (value) {
+            if (value) {
+              sessionStorage.setItem(cacheKey, value);
+              render(value);
+            }
+          })
+          .catch(function () {});
       }
-      var cached = sessionStorage.getItem("ov-github-stars");
-      if (cached) {
-        render(cached);
-        return;
+
+      function formatCount(n) {
+        n = parseInt(n, 10);
+        if (!n) return null;
+        return n >= 1000
+          ? (n / 1000).toFixed(1).replace(/\.0$/, "") + "k"
+          : String(n);
       }
-      fetch("https://api.github.com/repos/OpenVidu/openvidu")
-        .then(function (res) {
-          return res.ok ? res.json() : null;
-        })
-        .then(function (data) {
-          if (data && data.stargazers_count) {
-            sessionStorage.setItem("ov-github-stars", data.stargazers_count);
-            render(data.stargazers_count);
-          }
-        })
-        .catch(function () {});
+
+      setupCounter(
+        "github-stars-count",
+        "github-stars-segment",
+        "ov-github-stars",
+        function () {
+          return fetch("https://api.github.com/repos/OpenVidu/openvidu")
+            .then(function (res) {
+              return res.ok ? res.json() : null;
+            })
+            .then(function (data) {
+              return data ? formatCount(data.stargazers_count) : null;
+            });
+        }
+      );
+
+      // hub.docker.com's API sends no CORS headers, so the pull count is
+      // read from the shields.io badge for the repository (CORS-enabled,
+      // returns the count pre-formatted, e.g. "966k").
+      setupCounter(
+        "dockerhub-pulls-count",
+        "dockerhub-pulls-segment",
+        "ov-dockerhub-pulls",
+        function () {
+          return fetch(
+            "https://img.shields.io/docker/pulls/openvidu/openvidu-server"
+          )
+            .then(function (res) {
+              return res.ok ? res.text() : null;
+            })
+            .then(function (svg) {
+              var match =
+                svg && svg.match(/docker pulls:?\s*([\d.,]+\s?[kMB]?)/i);
+              return match ? match[1].trim() : null;
+            });
+        }
+      );
     })();
   </script>
 </section>

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -27,7 +27,7 @@
       draggable="false"
     />
   </div>
-  <h1 class="slogan">{{config.site_description}}</h1>
+  <h1 class="slogan">Ship video conferencing into your app,<br>self-hosted and production-ready in minutes.</h1>
   <p class="home-description">
     OpenVidu allows you to implement <strong>ultra-low latency</strong> video
     and audio applications with ease: one-to-one calls, videoconference rooms,
@@ -40,14 +40,33 @@
   </p>
   <div class="home-buttons">
     <a
-      title="Get started"
+      title="Get started with OpenVidu Meet"
+      id="home-primary-button"
+      class="md-button md-button--primary"
+      href="meet/"
+    >
+      Get started with Meet — it's free
+    </a>
+    <a
+      title="Build with OpenVidu Platform SDKs"
       id="home-secondary-button"
       class="md-button home-secondary-button"
+      href="docs/"
+    >
+      Build with Platform SDKs
+    </a>
+  </div>
+  <p class="home-under-cta">
+    Not sure which fits?
+    <a href="/openvidu-meet-vs-openvidu-platform/">Compare Meet vs Platform</a>
+    <span class="home-under-cta-sep">·</span>
+    <a
+      title="Start a tour"
       onclick="event.stopPropagation(); window.scrollTo({ top: (document.getElementById('get-started').getBoundingClientRect().top + window.scrollY - 80), behavior: 'smooth' })"
     >
       Start a tour
     </a>
-  </div>
+  </p>
 </section>
 
 {% endblock %}

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -78,6 +78,12 @@
       ></span
     >
   </p>
+  <p class="home-trust-line home-credentials-line">
+    🔬
+    <a href="/research/">19 peer-reviewed publications · 500+ citations</a>
+    · 🌐 12+ years building WebRTC · 🛠 Upstream contributors to LiveKit,
+    mediasoup &amp; Kurento
+  </p>
   <script>
     // Live counters for the hero trust line (GitHub stars, Docker Hub pulls).
     // Each value is cached per session, and its segment stays hidden if the

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -41,7 +41,7 @@
       class="md-button md-button--primary"
       href="meet/"
     >
-      Get started with Meet — it's free
+      Get started with Meet
     </a>
     <a
       title="Build with OpenVidu Platform SDKs"

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -38,7 +38,7 @@
     <a
       title="Get started with OpenVidu Meet"
       id="home-primary-button"
-      class="md-button md-button--primary"
+      class="md-button md-button--primary home-meet-button"
       href="meet/"
     >
       Get started with Meet
@@ -46,7 +46,7 @@
     <a
       title="Build with OpenVidu Platform SDKs"
       id="home-secondary-button"
-      class="md-button home-secondary-button"
+      class="md-button home-platform-button"
       href="docs/"
     >
       Build with Platform SDKs

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -114,12 +114,19 @@
           .catch(function () {});
       }
 
+      // Approximate a count, always rounding DOWN so the shown number is
+      // never higher than reality. Keeps two significant digits:
+      // 2115 -> "2.1k", 966155 -> "960k", 1134000 -> "1.1M".
       function formatCount(n) {
         n = parseInt(n, 10);
-        if (!n) return null;
-        return n >= 1000
-          ? (n / 1000).toFixed(1).replace(/\.0$/, "") + "k"
-          : String(n);
+        if (!n || n < 0) return null;
+        if (n >= 10) {
+          var magnitude = Math.pow(10, Math.floor(Math.log10(n)) - 1);
+          n = Math.floor(n / magnitude) * magnitude;
+        }
+        if (n >= 1000000) return parseFloat((n / 1000000).toFixed(1)) + "M";
+        if (n >= 1000) return parseFloat((n / 1000).toFixed(1)) + "k";
+        return String(n);
       }
 
       setupCounter(
@@ -137,24 +144,25 @@
         }
       );
 
-      // hub.docker.com's API sends no CORS headers, so the pull count is
-      // read from the shields.io badge for the repository (CORS-enabled,
-      // returns the count pre-formatted, e.g. "966k").
+      // hub.docker.com's API sends no CORS headers, so the RAW pull count is
+      // relayed through a shields.io dynamic-JSON badge (CORS-enabled) and
+      // then approximated client-side with formatCount, like the stars.
+      // (The standard shields docker/pulls badge pre-rounds the number, which
+      // would prevent our own floor-to-two-significant-digits rounding.)
       setupCounter(
         "dockerhub-pulls-count",
         "dockerhub-pulls-segment",
         "ov-dockerhub-pulls",
         function () {
           return fetch(
-            "https://img.shields.io/docker/pulls/openvidu/openvidu-server"
+            "https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fhub.docker.com%2Fv2%2Frepositories%2Fopenvidu%2Fopenvidu-server&query=%24.pull_count&label=pulls"
           )
             .then(function (res) {
               return res.ok ? res.text() : null;
             })
             .then(function (svg) {
-              var match =
-                svg && svg.match(/docker pulls:?\s*([\d.,]+\s?[kMB]?)/i);
-              return match ? match[1].trim() : null;
+              var match = svg && svg.match(/pulls:?\s*(\d+)\b/i);
+              return match ? formatCount(match[1]) : null;
             });
         }
       );

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -29,14 +29,10 @@
   </div>
   <h1 class="slogan">Ship video conferencing into your app,<br>self-hosted and production-ready in minutes.</h1>
   <p class="home-description">
-    OpenVidu allows you to implement <strong>ultra-low latency</strong> video
-    and audio applications with ease: one-to-one calls, videoconference rooms,
-    massive live streamings with thousands of viewers... It is built on the best
-    open source <strong>WebRTC stacks</strong> and packed with features:
-    multi-platform, recording, broadcasting, screen sharing, AI Agents and more.
-    From an operations perspective we aim to make it easy to
-    <strong>self-host</strong> a performant, fault-tolerant, scalable and
-    observable cluster, reducing DevOps efforts to a minimum.
+    Launch <strong>OpenVidu Meet</strong> on your own servers in minutes — or
+    build any real-time app with <strong>OpenVidu Platform</strong>'s WebRTC
+    SDKs. Open source, ultra-low latency, and scalable to thousands of
+    participants, with your users' data on your infrastructure.
   </p>
   <div class="home-buttons">
     <a
@@ -67,6 +63,47 @@
       Start a tour
     </a>
   </p>
+  <p class="home-trust-line">
+    ⭐ Open source · Apache 2.0<span id="github-stars-segment" hidden>
+      ·
+      <a href="https://github.com/OpenVidu/openvidu" target="_blank"
+        >★ <span id="github-stars-count"></span> on GitHub</a
+      ></span
+    >
+  </p>
+  <script>
+    // Live GitHub star count for the hero trust line. Cached per session;
+    // the segment stays hidden if the API is unavailable (rate limit,
+    // offline), so the line gracefully shortens to "Open source · Apache 2.0".
+    (function () {
+      var countEl = document.getElementById("github-stars-count");
+      var segmentEl = document.getElementById("github-stars-segment");
+      if (!countEl || !segmentEl) return;
+      function render(stars) {
+        var n = parseInt(stars, 10);
+        if (!n) return;
+        countEl.textContent =
+          n >= 1000 ? (n / 1000).toFixed(1).replace(/\.0$/, "") + "k" : n;
+        segmentEl.hidden = false;
+      }
+      var cached = sessionStorage.getItem("ov-github-stars");
+      if (cached) {
+        render(cached);
+        return;
+      }
+      fetch("https://api.github.com/repos/OpenVidu/openvidu")
+        .then(function (res) {
+          return res.ok ? res.json() : null;
+        })
+        .then(function (data) {
+          if (data && data.stargazers_count) {
+            sessionStorage.setItem("ov-github-stars", data.stargazers_count);
+            render(data.stargazers_count);
+          }
+        })
+        .catch(function () {});
+    })();
+  </script>
 </section>
 
 {% endblock %}

--- a/docs/stylesheets/colors.css
+++ b/docs/stylesheets/colors.css
@@ -101,14 +101,6 @@
   .home-trust-line {
     color: #ffffff;
   }
-  #home-secondary-button {
-    color: #ffffff;
-  }
-  #home-secondary-button:hover {
-    color: #ffffff;
-    background-color: var(--slate-md-typeset-color);
-    border-color: var(--slate-md-typeset-color);
-  }
   a#account-btn {
     color: var(--slate-md-typeset-color);
   }
@@ -139,5 +131,19 @@
 #home-primary-button:hover {
   background-color: #05b855;
   border-color: #05b855;
+  color: #ffffff;
+}
+
+/* Hero secondary CTA: OpenVidu Platform blue (same as the Platform product
+   card's Get Started button), so the two hero buttons mirror the product
+   cards' color identities. */
+#home-secondary-button {
+  background-color: #0088aa;
+  border-color: #0088aa;
+  color: #ffffff;
+}
+#home-secondary-button:hover {
+  background-color: #007394;
+  border-color: #007394;
   color: #ffffff;
 }

--- a/docs/stylesheets/colors.css
+++ b/docs/stylesheets/colors.css
@@ -97,7 +97,8 @@
     color: #ffffff;
   }
   .home-under-cta,
-  .home-under-cta a {
+  .home-under-cta a,
+  .home-trust-line {
     color: #ffffff;
   }
   #home-secondary-button {

--- a/docs/stylesheets/colors.css
+++ b/docs/stylesheets/colors.css
@@ -96,6 +96,10 @@
   .home-description {
     color: #ffffff;
   }
+  .home-under-cta,
+  .home-under-cta a {
+    color: #ffffff;
+  }
   #home-secondary-button {
     color: #ffffff;
   }
@@ -121,4 +125,19 @@
 
 .green-color {
   color: #2b9b46;
+}
+
+/* Hero primary CTA: brand accent in both themes so the main conversion
+   action stands out over the dark hero gradient (the grey .md-button--primary
+   background would blend into it). */
+#home-primary-button {
+  background-color: var(--md-accent-fg-color);
+  border-color: var(--md-accent-fg-color);
+  color: #ffffff;
+}
+#home-primary-button:hover {
+  background-color: var(--md-accent-fg-color);
+  border-color: var(--md-accent-fg-color);
+  color: #ffffff;
+  filter: brightness(1.2);
 }

--- a/docs/stylesheets/colors.css
+++ b/docs/stylesheets/colors.css
@@ -96,9 +96,9 @@
   .home-description {
     color: #ffffff;
   }
-  .home-under-cta,
-  .home-under-cta a,
-  .home-trust-line {
+  .top-home-section .home-under-cta,
+  .top-home-section .home-under-cta a,
+  .top-home-section .home-trust-line {
     color: #ffffff;
   }
   a#account-btn {
@@ -120,29 +120,26 @@
   color: #2b9b46;
 }
 
-/* Hero primary CTA: OpenVidu Meet green (same as the Meet product card's
-   Get Started button) in both themes, so the main conversion action stands
-   out over the dark hero gradient and is visually tied to Meet. */
-#home-primary-button {
+/* Audience-routed CTA buttons (hero and end of features grid): each product's
+   identity color (same as its product card's Get Started button) in both
+   themes, so green=Meet / blue=Platform routing is consistent page-wide. */
+.md-typeset .home-buttons .md-button.home-meet-button {
   background-color: #06d362;
   border-color: #06d362;
   color: #ffffff;
 }
-#home-primary-button:hover {
+.md-typeset .home-buttons .md-button.home-meet-button:hover {
   background-color: #05b855;
   border-color: #05b855;
   color: #ffffff;
 }
 
-/* Hero secondary CTA: OpenVidu Platform blue (same as the Platform product
-   card's Get Started button), so the two hero buttons mirror the product
-   cards' color identities. */
-#home-secondary-button {
+.md-typeset .home-buttons .md-button.home-platform-button {
   background-color: #0088aa;
   border-color: #0088aa;
   color: #ffffff;
 }
-#home-secondary-button:hover {
+.md-typeset .home-buttons .md-button.home-platform-button:hover {
   background-color: #007394;
   border-color: #007394;
   color: #ffffff;

--- a/docs/stylesheets/colors.css
+++ b/docs/stylesheets/colors.css
@@ -128,17 +128,16 @@
   color: #2b9b46;
 }
 
-/* Hero primary CTA: brand accent in both themes so the main conversion
-   action stands out over the dark hero gradient (the grey .md-button--primary
-   background would blend into it). */
+/* Hero primary CTA: OpenVidu Meet green (same as the Meet product card's
+   Get Started button) in both themes, so the main conversion action stands
+   out over the dark hero gradient and is visually tied to Meet. */
 #home-primary-button {
-  background-color: var(--md-accent-fg-color);
-  border-color: var(--md-accent-fg-color);
+  background-color: #06d362;
+  border-color: #06d362;
   color: #ffffff;
 }
 #home-primary-button:hover {
-  background-color: var(--md-accent-fg-color);
-  border-color: var(--md-accent-fg-color);
+  background-color: #05b855;
+  border-color: #05b855;
   color: #ffffff;
-  filter: brightness(1.2);
 }

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -267,7 +267,7 @@ p:has(> a.glightbox) {
 }
 
 .home-description {
-  font-size: 18px;
+  font-size: 1rem;
   text-align: center;
   max-width: 75rem;
   margin-left: auto;
@@ -287,7 +287,7 @@ p:has(> a.glightbox) {
 
 .home-under-cta {
   text-align: center;
-  font-size: 0.75rem;
+  font-size: 0.9rem;
   margin-top: 0.8em;
 }
 
@@ -302,7 +302,7 @@ p:has(> a.glightbox) {
 
 .home-trust-line {
   text-align: center;
-  font-size: 0.7rem;
+  font-size: 0.9rem;
   margin-top: 1.2em;
 }
 
@@ -403,7 +403,7 @@ p:has(> a.glightbox) {
   }
 
   .home-description {
-    font-size: 16px !important;
+    font-size: 0.9rem !important;
   }
 
   img.mkdocs-img {

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -268,8 +268,10 @@ p:has(> a.glightbox) {
 
 .home-description {
   font-size: 18px;
-  text-align: justify;
+  text-align: center;
   max-width: 75rem;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .home-buttons {

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -302,8 +302,8 @@ p:has(> a.glightbox) {
 
 .home-trust-line {
   text-align: center;
-  font-size: 0.9rem;
-  margin-top: 1.2em;
+  font-size: 0.8rem;
+  margin: 0;
 }
 
 .home-trust-line a {

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -318,7 +318,7 @@ p:has(> a.glightbox) {
 }
 
 .home-credentials-line {
-  margin-top: 0.15em;
+  margin-top: 0.5em;
 }
 
 .features-list:after {

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -311,8 +311,14 @@ p:has(> a.glightbox) {
   text-decoration: underline;
 }
 
+/* Claim separator: slightly smaller gap than the comparison/tour line's
+   .home-under-cta-sep (whose surrounding whitespace adds to its margins). */
+.home-trust-line .home-sep {
+  margin: 0 0.45em;
+}
+
 .home-credentials-line {
-  margin-top: 0.4em;
+  margin-top: 0.15em;
 }
 
 .features-list:after {

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -298,6 +298,17 @@ p:has(> a.glightbox) {
   margin: 0 0.5em;
 }
 
+.home-trust-line {
+  text-align: center;
+  font-size: 0.7rem;
+  margin-top: 1.2em;
+}
+
+.home-trust-line a {
+  color: inherit;
+  text-decoration: underline;
+}
+
 .features-list:after {
   clear: both;
   content: "";

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -311,6 +311,10 @@ p:has(> a.glightbox) {
   text-decoration: underline;
 }
 
+.home-credentials-line {
+  margin-top: 0.4em;
+}
+
 .features-list:after {
   clear: both;
   content: "";

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -283,6 +283,21 @@ p:has(> a.glightbox) {
   margin-left: 0.25em;
 }
 
+.home-under-cta {
+  text-align: center;
+  font-size: 0.75rem;
+  margin-top: 0.8em;
+}
+
+.home-under-cta a {
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.home-under-cta-sep {
+  margin: 0 0.5em;
+}
+
 .features-list:after {
   clear: both;
   content: "";

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: OpenVidu
 site_url: https://openvidu.io/
-site_description: From ready-to-use video conferencing apps<br>to custom-made WebRTC solutions.<br>Self-hosted. Performant. Scalable. Fault tolerant. Observable.
+site_description: "Self-hosted video conferencing and custom WebRTC solutions: deploy OpenVidu Meet in minutes or build with OpenVidu Platform SDKs. Open source and scalable."
 repo_name: openvidu/openvidu
 repo_url: https://github.com/openvidu/openvidu
 


### PR DESCRIPTION
## Landing hero conversion rework
 
  Fixes the top conversion issue from the marketing audit: the hero had **zero conversion actions above the fold** — a single secondary-styled "Start a tour" button that only scrolled the page, and neither product was named or clickable until the visitor scrolled.

  ### Tracker cross-references (marketing repo `critical-issues.md`)

  - ✅ Resolves **3** (hero has no conversion CTA) — the audit's recommended fix, applied as specified.
  - ✅ Resolves the sitewide-default half of **7** (generic `<br>` meta description); unique per-page descriptions remain open.
  - ⚠️  Partially covers **13** (GitHub star count) and **18** (open-source badge near CTAs) — heads-up @juancarmore  to avoid duplicate work; logos/testimonials from 13 remain open.