### PR TITLE
Add Open Graph and Twitter Card meta tags sitewide

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -91,6 +91,7 @@
 {% block extrahead %}
 <!-- Add head tags that need to be applied before here -->
 {{ super() }}
+{% include "partials/og.html" %}
 <!-- Add head tags that need to be applied afterwards here -->
 {% endblock %}
 

--- a/docs/overrides/partials/og.html
+++ b/docs/overrides/partials/og.html
@@ -1,0 +1,36 @@
+{#-
+  Open Graph + Twitter Card meta tags for social/chat link previews.
+
+  Platforms like Facebook, LinkedIn, Slack, WhatsApp, Discord and X read
+  og:*/twitter:* meta tags to render the preview card when a URL is shared.
+  They do NOT read JSON-LD (which serves search engines/AI crawlers), so both
+  are needed.
+
+  - og:title / og:description come from the page frontmatter, falling back to
+    the site defaults (any HTML like <br> in site_description is stripped).
+  - og:url uses the page canonical URL.
+  - og:image is a site-wide default card (the OpenVidu logo, ~1.9:1, close to
+    the recommended 1200x630) rendered as a large-image card. Replace with a
+    dedicated 1200x630 branded card, or per-page images, as a follow-up.
+  - Blog posts are typed og:type=article with their publication date.
+-#}
+{%- set og_is_post = page and page.file and page.file.src_uri.startswith("blog/posts/") %}
+{%- set og_title = page.meta.title if page and page.meta and page.meta.title else (page.title if page and page.title else config.site_name) %}
+{%- set og_description = page.meta.description if page and page.meta and page.meta.description else config.site_description %}
+{%- set og_description = og_description | replace("<br>", " ") | striptags %}
+<meta property="og:site_name" content="OpenVidu" />
+<meta property="og:type" content="{{ 'article' if og_is_post else 'website' }}" />
+<meta property="og:title" content="{{ og_title | e }}" />
+<meta property="og:description" content="{{ og_description | e }}" />
+{%- if page and page.canonical_url %}
+<meta property="og:url" content="{{ page.canonical_url }}" />
+{%- endif %}
+<meta property="og:image" content="https://openvidu.io/assets/images/openvidu_white_bg_transp.png" />
+<meta property="og:image:width" content="1497" />
+<meta property="og:image:height" content="807" />
+<meta property="og:image:alt" content="OpenVidu — self-hosted video conferencing and custom WebRTC solutions" />
+{%- if og_is_post and page.config and page.config.date and page.config.date.created %}
+<meta property="article:published_time" content="{{ page.config.date.created.strftime('%Y-%m-%d') }}" />
+{%- endif %}
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:site" content="@openvidu" />


### PR DESCRIPTION
Social and chat platforms (Facebook, LinkedIn, Slack, WhatsApp, Discord, X) render link previews from og:*/twitter:* meta tags and do not read JSON-LD, so shares of openvidu.io pages rendered as bare links. A new partial, included from main.html's extrahead block, emits on every page:

- og:title and og:description from the page frontmatter, falling back to the site defaults (HTML like <br> in site_description is stripped)
- og:url from the page canonical
- og:type article with article:published_time for blog posts, website elsewhere
- a site-wide og:image (OpenVidu logo, ~1.9:1) rendered as a summary_large_image Twitter Card, with twitter:site @openvidu

A dedicated 1200x630 branded card image (and per-page images for blog posts) is a suggested follow-up.