### PR TITLE
Issue 16: single homepage H1 + unique section anchor IDs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -12,8 +12,6 @@ tags:
   - setupcardglow
 ---
 
-# Home { .hide }
-
 <div class="second-slogan wow animated animatedFadeInUp fadeInUp">
   <h2 id="get-started">
     Choose the ideal OpenVidu solution for your real-time needs
@@ -82,7 +80,7 @@ tags:
 <hr style="margin: 7em 0;">
 
 <div class="second-slogan wow animated animatedFadeInUp fadeInUp">
-  <h2 id="get-started">
+  <h2 id="self-host-platform">
     Self-host a production-ready live-video platform with advanced capabilities typically reserved for expensive SaaS solutions
   </h2>
 </div>
@@ -144,7 +142,7 @@ tags:
 <hr style="margin: 7em 0;">
 
 <div class="second-slogan wow animated animatedFadeInUp fadeInUp">
-  <h2 id="get-started">
+  <h2 id="all-features">
     All the features you need to quickly build your perfect real-time application
   </h2>
 </div>

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -180,3 +180,12 @@
 </section>
 
 {% endblock %}
+
+{# The hero above already provides the page's single <h1> (.slogan). Render the
+   markdown body directly so Material's content.html does NOT auto-inject a
+   second <h1> (page title) when the body has no heading of its own. The landing
+   page hides nav/toc/footer/search, so the edit/feedback/comments partials are
+   intentionally omitted too. #}
+{% block content %}
+  {{ page.content }}
+{% endblock %}


### PR DESCRIPTION
The homepage rendered two h1s (the visible .slogan hero heading plus a hidden "Home" heading from ` Home { .hide }`) and three h2 sections all sharing id="get-started" — invalid HTML that splits the page's heading signal and makes the #get-started fragment ambiguous.

- Remove the ` Home { .hide }` markdown heading. Because Material's content.html auto-injects `<h1>{{ page.title }}</h1>` whenever the body has no `<h1>`, a home-scoped `{% block content %}{{ page.content }}{% endblock %}` override is added to home.html so no page-title H1 is re-injected. The slogan is now the page's single `<h1>`.
- Rename the 2nd/3rd `get-started` anchors to `self-host-platform` and `all-features`; the first keeps `get-started` since the hero "Start a tour" button scrolls to it via getElementById('get-started').

Verified on a local mkdocs-material build: rendered / now has exactly one `<h1>` and one `id="get-started"`, tour scroll intact, all sections present.