### PR TITLE
chore: update OpenVidu/actions to v1.0.22

### DIFF
--- a/.github/workflows/publish-web.yaml
+++ b/.github/workflows/publish-web.yaml
@@ -31,7 +31,7 @@ jobs:
         with:
           python-version: 3.x
       - name: Install safe-chain
-        uses: OpenVidu/actions/install-safe-chain@040cbfd01320475801d7b12e33769e0d55a737a8 # v1.0.21
+        uses: OpenVidu/actions/install-safe-chain@070fb73fda8fe7a08e28991b1c2d276f12a009ef # v1.0.22
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/validate-web.yaml
+++ b/.github/workflows/validate-web.yaml
@@ -45,7 +45,7 @@ jobs:
           python-version: 3.x
 
       - name: Install safe-chain
-        uses: OpenVidu/actions/install-safe-chain@040cbfd01320475801d7b12e33769e0d55a737a8 # v1.0.21
+        uses: OpenVidu/actions/install-safe-chain@070fb73fda8fe7a08e28991b1c2d276f12a009ef # v1.0.22
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Updates pinned references of `OpenVidu/actions` to `v1.0.22`.

Auto-generated by the [update-pinned-actions](https://github.com/OpenVidu/actions/actions/workflows/update-pinned-actions.yml) workflow.