### PR TITLE
#16: add alt="" to the two remaining homepage images

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -168,7 +168,7 @@ tags:
 
     Fine-grained access control and highly secure deployments for the most demanding security requirements. E2EE (End-to-End Encryption) support.
 
--   <span class="twemoji feature-icon"><img class="do-not-include-in-gallery custom-svg-icon" src="/assets/images/home/multiplatform.svg" class="feature-icon"/></span> __Multiplatform__{ .feature-name }
+-   <span class="twemoji feature-icon"><img class="do-not-include-in-gallery custom-svg-icon" src="/assets/images/home/multiplatform.svg" class="feature-icon" alt=""/></span> __Multiplatform__{ .feature-name }
 
     ---
 

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -25,6 +25,7 @@
       class="top-home-img"
       src="assets/images/logos/openvidu_white_bg_transp.png"
       draggable="false"
+      alt=""
     />
   </div>
   <h1 class="slogan">Ship video conferencing into your app,<br>self-hosted and production-ready in minutes.</h1>


### PR DESCRIPTION
## Summary

Closes the last open sub-item of issue #16 (landing HTML validity — H1/anchor dedup already shipped in #90). Live re-verification found 2 of the homepage's 20 `<img>` tags still had no `alt` attribute: the hero logo (`docs/overrides/home.html`) and the "Multiplatform" feature icon (`docs/index.md`, the only feature icon that's a raw `<img>` instead of a Material icon shortcode).

Both are decorative: the hero logo sits directly above an H1 that already states the message, and the feature icon sits right next to a "Multiplatform" text label — so `alt=""` is correct, matching how issue #28 already treated the product-page logos as decorative rather than giving them redundant descriptive text.

## Test plan

- [x] Local build: `grep -c` confirms 0 of 20 homepage `<img>` tags now missing `alt`
- [x] Screenshot comparison: no visual change (alt is non-visual metadata)
- [ ] After merge + deploy: re-check `curl -s https://openvidu.io/ | grep -o '<img[^>]*>' | grep -v 'alt='` returns nothing

https://claude.ai/code/session_01QvvHLimJQaX3rSbyzQhBiV