### PR TITLE
Only explain the version jump when it came from another version's release notes

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -87,20 +87,42 @@
       link.href = currentPath.replace(/^\/[^\/]+\//, '/latest/');
     }
 
-    // If the user landed on this older version by following a link from a release notes
-    // page, explain why they were moved here instead of showing the generic warning.
-    let fromReleaseNotes = false;
+    // Split "/3.4/docs/foo/" into its version segment ("3.4") and the rest ("docs/foo/")
+    const splitVersion = (path) => {
+      const segments = path.replace(/^\//, '').split('/');
+      return { version: segments[0], rest: segments.slice(1).join('/') };
+    };
+
+    // Replace the generic warning only when the visitor got here by following a link that
+    // lives inside ANOTHER version's release notes: that version jump is the one thing that
+    // needs explaining. Everything else keeps the generic "old version" warning, and the two
+    // conditions below are what tell them apart:
+    //
+    //   - A DIFFERENT version segment. The navigation menu, tabs, footer and search links
+    //     never leave the version being browsed, so any click on them lands on the same
+    //     version and is ruled out here — including clicks made from a releases page, and
+    //     links inside the release notes that point at their own version.
+    //   - A DIFFERENT path after the version segment. The version selector DOES change the
+    //     version, but it lands on the same page of another version
+    //     (/latest/docs/releases/ -> /3.4/docs/releases/), so it is ruled out here. Release
+    //     notes never link to the same page of another version: their cross-links between
+    //     the two products always change the product too (docs/releases -> meet/releases).
+    let fromOtherVersionReleaseNotes = false;
     try {
       if (document.referrer) {
         const referrer = new URL(document.referrer);
-        fromReleaseNotes =
+        const from = splitVersion(referrer.pathname);
+        const here = splitVersion(currentPath);
+        fromOtherVersionReleaseNotes =
           referrer.origin === window.location.origin &&
-          /\/(meet|docs)\/releases\/?$/.test(referrer.pathname);
+          /^(meet|docs)\/releases\/?$/.test(from.rest) &&
+          from.version !== here.version &&
+          from.rest !== here.rest;
       }
     } catch (e) {}
 
     const warning = document.getElementById('outdated-warning-text');
-    if (warning && fromReleaseNotes && version && version !== 'latest') {
+    if (warning && fromOtherVersionReleaseNotes && version && version !== 'latest') {
       warning.innerHTML =
         `<strong>Warning:</strong> You are viewing the <strong>${version}</strong> version of the docs<br />` +
         `because you followed a link from the ${version}.x release notes<br />`;


### PR DESCRIPTION
## Problem

The outdated-version banner swaps its generic text ("*You are reading docs for an old version*") for a specific one ("*You are viewing the **3.4** version of the docs because you followed a link from the 3.4.x release notes*") based on `document.referrer`. The test only asked whether the referrer was **a** releases page:

```js
/\/(meet|docs)\/releases\/?$/.test(referrer.pathname)
```

So it fired in three cases where no release-notes link had been followed at all:

1. **Switching version from a releases page** with the version selector (`/latest/docs/releases/` → `/3.4/docs/releases/`).
2. **Clicking a navigation entry** from an old version's releases page.
3. **Clicking a link inside that same version's own release notes.**

## Fix

Two conditions now separate the real case from the rest:

- **The version segment must differ.** The navigation menu, tabs, footer and search links never leave the version being browsed, so any click on them lands on the same version — this rules out cases 2 and 3 at once, including notes linking to their own version.
- **The path after the version segment must differ.** The version selector *does* change the version, but it lands on the same page of another version, which rules out case 1. Release notes never link to the same page of another version: their cross-links between the two products always change the product too (`docs/releases` → `meet/releases`), so this costs no real case.

The referrer regex is also anchored to the path after the version segment, so it matches `/<version>/<meet|docs>/releases/` exactly rather than any path ending that way.

## Verification

Each `(referrer → destination)` pair was driven through a real headless Chrome against the built site, setting the referrer exactly via the DevTools protocol, and asserting which message appears. The same 11 cases were run against the pre-fix and post-fix builds:

| case | referrer → destination | expected | before | after |
| --- | --- | --- | --- | --- |
| version selector, releases page | `/latest/docs/releases/` → `/3.4/docs/releases/` | generic | ❌ specific | ✅ |
| version selector, meet releases | `/latest/meet/releases/` → `/3.4/meet/releases/` | generic | ❌ specific | ✅ |
| nav click from old releases page | `/3.4/docs/releases/` → `/3.4/meet/features/recordings/` | generic | ❌ specific | ✅ |
| link in SAME version notes | `/3.4/docs/releases/` → `/3.4/docs/comparing-openvidu/` | generic | ❌ specific | ✅ |
| link in OTHER version notes | `/latest/docs/releases/` → `/3.4/docs/comparing-openvidu/` | specific | ✅ | ✅ |
| from an older releases page | `/3.8/docs/releases/` → `/3.4/meet/features/recordings/` | specific | ✅ | ✅ |
| meet notes → platform docs | `/latest/meet/releases/` → `/3.4/docs/comparing-openvidu/` | specific | ✅ | ✅ |
| cross-product cross-link | `/latest/meet/releases/` → `/3.4/docs/releases/` | specific | ✅ | ✅ |
| no referrer | — → `/3.4/docs/releases/` | generic | ✅ | ✅ |
| referrer is a normal old page | `/3.4/meet/features/recordings/` → `/3.4/docs/comparing-openvidu/` | generic | ✅ | ✅ |
| referrer is an external site | `https://example.com/some/docs/releases/` → `/3.4/docs/releases/` | generic | ✅ | ✅ |

Before: 4 failures, exactly the reported cases. After: 11/11. `mkdocs build --strict` passes.

## Deployment

The banner script is baked into every built page, so this only takes effect where a version is rebuilt. The same change is backported to branches `3.0`–`3.7` (byte-identical block on all nine refs, verified by hash), and every version is republished.

🤖 Generated with [Claude Code](https://claude.com/claude-code)