### PR TITLE
Record the real cause of the 3.7 contamination

### DIFF
--- a/publish-tool/ovweb.yaml
+++ b/publish-tool/ovweb.yaml
@@ -201,14 +201,19 @@ redirects:
     # exist in the tree, which is what catches getting this wrong.
     #
     # Read the gate from the RELEASE a change belongs to, not from the current contents of a
-    # version folder — for the Meet features and the community Oracle tutorial those disagree.
-    # The 3.7 folder holds part of the 3.8 documentation: the reorganisation reached `main` from
-    # `next` on 2026-06-23, and re-publishing the then-current 3.7.0 folder from `main` — which
-    # is how a blog post went live — swept unreleased 3.8 pages into a released version. The
-    # 3.7.0 folder was correct until 2026-06-22 (see the gh-pages history), and the minor-grouped
-    # 3.7 folder inherited the corrupted state when branch 3.7 was cut from `main` at the last
-    # commit that had been deployed to 3.7.0. Those rules are therefore gated `>=3.8`, which is
-    # where the change actually belongs, and a rebuilt 3.7 keeps serving its own pages.
+    # version folder — for the Meet features those two disagreed, and it is worth knowing why.
+    #
+    # Unreleased 3.8 documentation lives on `next` until its release. One blog branch was cut
+    # from `next` instead of `main`, so merging that blog PR (2481b7146, 2026-06-23) carried 14
+    # documentation commits into `main` with it — the Meet features reorganisation, the members
+    # tutorials and the Oracle Elastic/HA guides. The next publish of 3.7, which builds from
+    # `main`, then served them inside a released version, and the 3.7 folder kept them until
+    # 2026-08-03. A one-off branching mistake, not a flaw in the release process: `next` had not
+    # been merged to `main`, one branch had simply been taken from the wrong base.
+    #
+    # So a version folder is evidence of what was published, not of what a release contained.
+    # These rules are gated at the release the change belongs to, and the rebuilt 3.7 serves its
+    # own pages again.
 
     - id: renamed-force-single-port
       description: >
@@ -291,9 +296,9 @@ redirects:
       versions: ">=3.8"
 
     # The Meet features section was reorganised per feature area. 1,449 impressions a year
-    # across the four. The reorganisation shipped in **3.8**, not 3.7: it reached `main`
-    # from `next` on 2026-06-23 and was published into the then-current 3.7.0 folder by a
-    # blog-post deploy, which is why 3.7 appears to hold it. See the note below.
+    # across the four. The reorganisation shipped in **3.8**, not 3.7 — the 3.7 folder held it
+    # for six weeks because a blog branch was cut from `next` and merged into `main` with 3.8's
+    # documentation attached. See the note above the group.
     - id: moved-meet-features-users
       at: "{version}/meet/features/users-and-permissions/index.html"
       to: "../users/overview/"

--- a/publish-tool/tests/unit/test_redirects.py
+++ b/publish-tool/tests/unit/test_redirects.py
@@ -450,11 +450,11 @@ def test_the_meet_reorganisation_rules_start_at_3_8_not_3_7(config):
     """The pages these rules replace are still published in a correct 3.7, so a stub installed
     there would overwrite a real page.
 
-    3.7 *appears* not to have them because the reorganisation reached `main` from `next` on
-    2026-06-23 and a blog-post publish rebuilt the then-current 3.7.0 folder from `main`,
-    sweeping unreleased 3.8 documentation into a released version. The 3.7 folder inherited that
-    when the minor-grouped folders were backfilled. The gate describes the release the change
-    belongs to, not the folder's current contents.
+    For six weeks the 3.7 folder appeared not to have them, which is what made these gates look
+    like 3.7 in the first place. One blog branch had been cut from `next` rather than `main`, so
+    merging it (2481b7146) brought 14 of 3.8's documentation commits into `main`, and the next
+    3.7 publish served them. The gate describes the release a change belongs to; the folder is
+    only evidence of what was published.
     """
     for version in ("3.6", "3.7"):
         installed = {item.rule_id for item in resolve_file_redirects(config, version)}


### PR DESCRIPTION
Corrected by Juan Carlos. My earlier note blamed the release process; it isn't at fault.

`next` holds unreleased documentation and is not merged to `main` until a release — that held. The actual mistake is narrower: **one blog branch was cut from `next` instead of `main`**, so merging that blog PR carried 3.8's documentation into `main` with it.

Verified in the history:

```
2481b7146  Merge pull request #69 from OpenVidu/blog/conversational-ai
  parents: 8b725ad1d (main)  5fb17a94f (blog branch)
  blog side contributes 35 commits, 14 of them documentation, including
    325085003  "Merge branch 'next' … into next"   <- the mis-branch, showing through
```

The reorganisation was **not** in `main` before that merge, and no other merge introduced it — later ones only inherit it through `main`'s history. So the publish behaved correctly all along: it built `main`, and `main` had wrongly received unreleased work.

Comments and one test docstring. No behaviour change, so no publish is needed — the live site already serves the corrected 3.7.

Board issue #52 is closed as declined for the same reason: there is no process to change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)