### PR TITLE
Adjust four redirect targets and retire six URLs that should not exist

### DIFF
--- a/publish-tool/README.md
+++ b/publish-tool/README.md
@@ -212,17 +212,25 @@ evaluated with `packaging`, so `3.10` correctly sorts above `3.9` and legacy fol
 version** — an overlap is an error, not a silent first-match-wins, because that would make the
 published redirect depend on the order of the file.
 
-Twenty-six rules ship today. Three are structural — the version root, `/X.Y/docs/getting-started/`
+Twenty rules ship today. Three are structural — the version root, `/X.Y/docs/getting-started/`
 → `/X.Y/docs/` for 3.4 and later, and `/X.Y/docs/` → `/X.Y/docs/getting-started/` for 3.0–3.3 — and
 the rest each rescue one page that was renamed or removed without a redirect. Those were found two
 ways, and both were needed:
 
 - **A 12-month Search Console export**, checked URL by URL against the live site: 13 `/latest/`
   URLs answered 404 while still ranking, worth 11,825 impressions a year.
-- **Diffing the version folders**: every page any published `X.Y` folder holds that 3.8 does not.
-  That set is 23, so it found the same 13 plus 10 more. Five of those ten existed in 3.7 only — a
-  URL that lived for one release has had little time to earn impressions, which is exactly why an
-  impressions-ranked list cannot find it.
+- **Diffing the version folders**: every page any published `X.Y` folder held that 3.8 does not.
+  That set is 23, so it found the same 13 plus 10 more, and an impressions-ranked list could not
+  have found several of them — a URL that lived for one release has had no time to earn
+  impressions.
+
+**Not every dead URL earns a redirect.** Six of the 23 deliberately have none. Five were never part
+of a release: they reached the site only through the 3.7 folder while it was serving mis-branched
+3.8 documentation, and 3.8 renamed them before shipping, so a redirect would preserve URLs that
+should not have existed. The sixth is a generated API page for a class that was deleted. The
+exclusions are pinned in [`test_redirects.py`](tests/unit/test_redirects.py) as
+`DELIBERATELY_UNCOVERED`, which fails both ways — if a listed URL gains a rule, and if an
+unlisted dead URL loses one.
 
 **A rule's `versions` gate must not be wider than its target's.** Gate a rule at the first version
 that stopped shipping the old page, then check that the *successor* exists in every version from

--- a/publish-tool/ovweb.yaml
+++ b/publish-tool/ovweb.yaml
@@ -149,7 +149,7 @@ redirects:
         # guide *was* the Platform documentation index.
         - versions: "<3.4"
           to: "docs/getting-started/"
-          body: "Redirecting to the OpenVidu Platform getting started guide…"
+          body: "Redirecting to the OpenVidu getting started guide…"
 
     - id: platform-getting-started
       description: >
@@ -250,12 +250,13 @@ redirects:
 
     - id: removed-self-hosting-faq
       description: >
-        The self-hosting FAQ was removed after 3.4. Deployment types is the section's entry
-        point and the closest surviving answer to what that page covered.
+        The self-hosting FAQ was removed after 3.4. The how-to guides are the section closest to
+        it in kind — task-shaped answers to specific self-hosting questions — so they get the
+        traffic rather than the deployment-types overview.
       at: "{version}/docs/self-hosting/faq/index.html"
-      to: "../deployment-types/"
-      canonical: "{site_url}/latest/docs/self-hosting/deployment-types/"
-      body: "Redirecting to OpenVidu deployment types…"
+      to: "../how-to-guides/"
+      canonical: "{site_url}/latest/docs/self-hosting/how-to-guides/"
+      body: "Redirecting to the OpenVidu self-hosting how-to guides…"
       versions: ">=3.5"
 
     # OpenVidu Meet embedded tutorials were grouped into embedding-options/ and
@@ -331,64 +332,21 @@ redirects:
     #
     # The rules above came from a Search Console export, so they are the dead URLs that still
     # earn impressions. This group came from the complement of that: every page under `docs/`
-    # or `meet/` that any published version folder holds and 3.8 does not — 22 paths, of which
-    # the export had found 13. The nine below are the remainder, plus one dropped API export.
+    # or `meet/` that any published version folder held and 3.8 does not.
     #
-    # Five of the nine lived in 3.7 only. A URL that existed for one release has had little
-    # time to accumulate impressions, which is exactly why an impressions-ranked list misses
-    # it — not evidence that nobody follows it.
+    # That scan found 23 paths where the export had found 13, and the ten extra split in two.
+    # Six of them — the External and Registered Members tutorials, rooms/creation-management,
+    # recordings/creation-management, rooms/appearance and an E2eeService API page — get **no**
+    # rule. The first five were never part of a release: they reached the site only through the
+    # 3.7 folder while it was serving mis-branched 3.8 documentation (see the note above), and
+    # 3.8 renamed them before shipping, so redirecting them would be preserving URLs that should
+    # not have existed. The sixth is a generated API page for a class that was deleted, published
+    # for one release.
     #
-    # Each gate is the first version that stopped shipping the page, read off the version
-    # folders rather than guessed, and each target was checked to exist in every version from
-    # that gate onwards. `moved-meet-features-users` above is why that second check matters.
-
-    # OpenVidu Meet's embedded tutorials were regrouped in 3.8 and two were renamed with them.
-    # The successor pages are rewrites of these, near-identical paragraph by paragraph.
-    - id: moved-meet-tutorial-external-members
-      description: >
-        "External members" became "identified guests" in 3.8: a room member with a fixed name
-        and a unique, individually revocable access link that needs no login.
-      at: "{version}/meet/embedded/tutorials/external-members/index.html"
-      to: "../access/identified-guests/"
-      canonical: "{site_url}/latest/meet/embedded/tutorials/access/identified-guests/"
-      body: "Redirecting to the OpenVidu Meet identified guests tutorial…"
-      versions: ">=3.8"
-
-    - id: moved-meet-tutorial-registered-members
-      description: >
-        "Registered members" became "users" in 3.8. Both cover creating OpenVidu Meet users
-        with the Users API and adding them to a room as members.
-      at: "{version}/meet/embedded/tutorials/registered-members/index.html"
-      to: "../access/users/"
-      canonical: "{site_url}/latest/meet/embedded/tutorials/access/users/"
-      body: "Redirecting to the OpenVidu Meet users tutorial…"
-      versions: ">=3.8"
-
-    # The Meet features section was reorganised again in 3.8, dropping "creation-" from the two
-    # management pages and folding room appearance into room management.
-    - id: moved-meet-features-rooms-management
-      at: "{version}/meet/features/rooms/creation-management/index.html"
-      to: "../management/"
-      canonical: "{site_url}/latest/meet/features/rooms/management/"
-      body: "Redirecting to OpenVidu Meet room creation and management…"
-      versions: ">=3.8"
-
-    - id: moved-meet-features-recordings-management
-      at: "{version}/meet/features/recordings/creation-management/index.html"
-      to: "../management/"
-      canonical: "{site_url}/latest/meet/features/recordings/management/"
-      body: "Redirecting to OpenVidu Meet recording management…"
-      versions: ">=3.8"
-
-    - id: moved-meet-features-rooms-appearance
-      description: >
-        Room appearance is no longer a page of its own: 3.8's room management page covers it,
-        which is where every mention of it now lives.
-      at: "{version}/meet/features/rooms/appearance/index.html"
-      to: "../management/"
-      canonical: "{site_url}/latest/meet/features/rooms/management/"
-      body: "Redirecting to OpenVidu Meet room creation and management…"
-      versions: ">=3.8"
+    # The four below are the ones worth keeping alive. Each gate is the first version that
+    # stopped shipping the page, read off the version folders rather than guessed, and each
+    # target was checked to exist in every version from that gate onwards —
+    # `removed-openvidu-call-docs` needs a `when` for 3.4 for exactly that reason.
 
     # OpenVidu Call was the ready-to-use meeting application documented up to 3.3. OpenVidu Meet
     # replaced it, and the timing corroborates the mapping: these two pages disappear in exactly
@@ -403,11 +361,21 @@ redirects:
       versions: ">=3.4"
 
     - id: removed-openvidu-call-docs
+      description: >
+        The page that documented how to run and customise the OpenVidu Call application. Its
+        closest successor is the components demo tutorial, which is the ready-to-run application
+        built from openvidu-components-angular. That tutorial first exists in 3.5, so 3.4 lands on
+        the Angular components tutorials index instead.
       at: "{version}/docs/openvidu-call/docs/index.html"
-      to: "../../../meet/"
-      canonical: "{site_url}/latest/meet/"
-      body: "Redirecting to OpenVidu Meet, which replaced OpenVidu Call…"
+      to: "../../tutorials/angular-components/openvidu-components-demo/"
+      canonical: "{site_url}/latest/docs/tutorials/angular-components/openvidu-components-demo/"
+      body: "Redirecting to the OpenVidu components demo tutorial…"
       versions: ">=3.4"
+      when:
+        - versions: "<3.5"
+          to: "../../tutorials/angular-components/"
+          canonical: "{site_url}/latest/docs/tutorials/angular-components/"
+          body: "Redirecting to the OpenVidu Angular components tutorials…"
 
     # The two recording tutorials were split per storage backend in 3.2. Both originals used
     # S3-compatible storage — MinIO in the local deployment — so the S3 variant is the one that
@@ -429,13 +397,6 @@ redirects:
     # The one dropped API export. E2eeService was published for 3.5 only and the class is gone,
     # so there is no successor page — the library's API index is the nearest thing. Named as a
     # file rather than a directory because typedoc output is not a directory URL.
-    - id: removed-e2ee-service-reference
-      at: "{version}/docs/reference-docs/openvidu-components-angular/injectables/E2eeService.html"
-      to: "../"
-      canonical: "{site_url}/latest/docs/reference-docs/openvidu-components-angular/"
-      body: "Redirecting to the openvidu-components-angular API reference…"
-      versions: ">=3.6"
-
   # Redirects compiled into the 404 router (docs/overrides/404.html). GitHub Pages has no
   # server-side redirects, so a pattern — as opposed to a single known path — can only be
   # handled by the page GitHub serves for an unmatched URL.

--- a/publish-tool/tests/unit/test_redirects.py
+++ b/publish-tool/tests/unit/test_redirects.py
@@ -478,10 +478,25 @@ def test_both_oracle_tutorial_rules_start_at_3_7(config):
     assert "removed-oracle-install-tutorial-community" in installed
 
 
+#: Dead URLs left without a rule on purpose. The first five were never part of a release —
+#: they reached the site only through the 3.7 folder while it served mis-branched 3.8
+#: documentation, and 3.8 renamed them before shipping — so a redirect would preserve URLs that
+#: should not have existed. The last is a generated API page for a deleted class, one release long.
+DELIBERATELY_UNCOVERED = {
+    "meet/embedded/tutorials/external-members/",
+    "meet/embedded/tutorials/registered-members/",
+    "meet/features/rooms/creation-management/",
+    "meet/features/recordings/creation-management/",
+    "meet/features/rooms/appearance/",
+    "docs/reference-docs/openvidu-components-angular/injectables/E2eeService.html",
+}
+
+
 def test_every_dead_page_of_every_version_has_a_rule(config):
-    """The rules were derived by scanning the version folders for pages 3.8 no longer has, so
-    the newest publish must cover all of them. Restated here as the set the scan produced: a
-    rule quietly dropped from ovweb.yaml would otherwise reinstate a 404 that used to rank."""
+    """The rules were derived by scanning the version folders for pages 3.8 no longer has, so the
+    newest publish must cover all of them bar the exclusions above. Restated here as the set the
+    scan produced: a rule quietly dropped from ovweb.yaml would otherwise reinstate a 404 that
+    used to rank, and an exclusion quietly gaining a rule would revive a URL we chose to retire."""
     dead = {
         # Found by a Search Console export (PR #108).
         "docs/self-hosting/faq/",
@@ -502,16 +517,15 @@ def test_every_dead_page_of_every_version_has_a_rule(config):
         "docs/openvidu-call/docs/",
         "docs/tutorials/advanced-features/recording-advanced/",
         "docs/tutorials/advanced-features/recording-basic/",
-        "meet/embedded/tutorials/external-members/",
-        "meet/embedded/tutorials/registered-members/",
-        "meet/features/recordings/creation-management/",
-        "meet/features/rooms/appearance/",
-        "meet/features/rooms/creation-management/",
-        "docs/reference-docs/openvidu-components-angular/injectables/E2eeService.html",
+        *DELIBERATELY_UNCOVERED,
     }
     installed = set()
     for item in resolve_file_redirects(config, "3.8"):
         path = item.path[len("3.8/") :]
         installed.add(path[: -len("index.html")] if path.endswith("/index.html") else path)
 
-    assert not dead - installed, f"no rule covers {sorted(dead - installed)}"
+    assert not dead - installed - DELIBERATELY_UNCOVERED, (
+        f"no rule covers {sorted(dead - installed - DELIBERATELY_UNCOVERED)}"
+    )
+    revived = installed & DELIBERATELY_UNCOVERED
+    assert not revived, f"these were retired on purpose, not to be redirected: {sorted(revived)}"


### PR DESCRIPTION
Takes the file rules from **26 to 20**.

## Changed targets

| URL | was | now |
|---|---|---|
| `docs/self-hosting/faq/` | `deployment-types/` | **`how-to-guides/`** — closest to a FAQ in kind: task-shaped answers to specific questions, not an overview |
| `docs/openvidu-call/docs/` | `meet/` | **`tutorials/angular-components/openvidu-components-demo/`** — the ready-to-run app built from openvidu-components-angular, closest successor to the application that page documented |

The components demo tutorial first exists in **3.5**, so `removed-openvidu-call-docs` carries a `when` sending 3.4 to the Angular components tutorials index. That's the same trap `moved-meet-features-users` fell into last week — this time the redirect-target check caught it before review did.

`docs/openvidu-call/` (the parent) still goes to `meet/`.

## Retired, not redirected

Six dead URLs now deliberately have **no** rule:

```
meet/embedded/tutorials/external-members/
meet/embedded/tutorials/registered-members/
meet/features/rooms/creation-management/
meet/features/recordings/creation-management/
meet/features/rooms/appearance/
docs/reference-docs/.../injectables/E2eeService.html
```

The first five **were never part of a release.** They reached the site only through the 3.7 folder while it was serving mis-branched 3.8 documentation, and 3.8 renamed them before shipping — so redirecting them would preserve URLs that should not have existed. The sixth is generated API output for a deleted class, published for one release.

They're pinned as `DELIBERATELY_UNCOVERED` in `test_redirects.py`, and the coverage test now fails **both** ways: an unlisted dead URL losing its rule, or a listed one quietly gaining one.

## Verification

- 20 rules resolve for 3.0–3.8; every target exists in every version its rule installs into, including the 3.4 override; no rule lands on a real page.
- 390 tests, `ruff check` and `ruff format --check` clean.

Needs a publish of `latest 3.8` and `past 3.7` to take effect — those are the only two folders carrying stubs from these rules, and each publish rebuilds its folder from scratch, so the six retired stubs disappear rather than lingering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)