### PR TITLE
Restore the word dropped from the 3.0-3.3 version-root body

### DIFF
--- a/publish-tool/ovweb.yaml
+++ b/publish-tool/ovweb.yaml
@@ -149,7 +149,7 @@ redirects:
         # guide *was* the Platform documentation index.
         - versions: "<3.4"
           to: "docs/getting-started/"
-          body: "Redirecting to the OpenVidu getting started guide…"
+          body: "Redirecting to the OpenVidu Platform getting started guide…"
 
     - id: platform-getting-started
       description: >


### PR DESCRIPTION
An unintended edit in 99304fb96 dropped "Platform" from the `version-root` rule's `<3.4` body:

```diff
-          body: "Redirecting to the OpenVidu Platform getting started guide…"
+          body: "Redirecting to the OpenVidu getting started guide…"
```

That left it out of step with `legacy-docs-index`, which serves the same version band and still reads "OpenVidu Platform getting started guide". I found it while preparing to run `ovweb redirects apply` over the older version folders: the apply reported **4 modified files** in 3.0–3.3 where it should have been purely additive, and the diff was this one word.

Only the fallback sentence shown if a browser blocks the meta refresh, so nothing was broken. Restoring it means the pending apply writes the 19 missing redirect pages and touches nothing else.

I audited the rest of both of today's `ovweb.yaml` commits line by line — every other change in them was intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)