### PR TITLE
Add OpenVidu vs Jitsi and OpenVidu vs Janus comparison landing pages

### DIFF
--- a/docs/docs/comparing-openvidu.md
+++ b/docs/docs/comparing-openvidu.md
@@ -1,6 +1,6 @@
 ---
-title: "OpenVidu vs LiveKit Cloud, SaaS and SFUs"
-description: "How OpenVidu compares with LiveKit Cloud, SaaS video APIs and bare SFUs like mediasoup, on cost, data control, features and operational effort."
+title: "OpenVidu vs LiveKit, Jitsi, SaaS and SFUs"
+description: "How OpenVidu compares with LiveKit, Jitsi, SaaS video APIs and bare SFUs like mediasoup and Janus, on cost, data control, features and effort."
 tags:
     - setupcustomgallery
 ---
@@ -60,6 +60,12 @@ Where does OpenVidu Pro stand in relation to LiveKit Cloud? **OpenVidu Pro aims 
 
 :octicons-arrow-right-24: **[Read the full OpenVidu vs LiveKit comparison](../openvidu-vs-livekit.md)**, including code samples, benchmarks, pricing and an honest look at where LiveKit still has the edge.
 
+## OpenVidu vs Jitsi
+
+[Jitsi :fontawesome-solid-external-link:{.external-link-icon}](https://jitsi.org/){:target="_blank"} is the other major open-source, self-hosted video platform, but it shares no codebase with OpenVidu the way LiveKit does — this is a peer comparison, not a compatibility one. Jitsi's architecture splits signaling (Prosody), conference orchestration (Jicofo) and media routing (Jitsi Videobridge) into separate components, whereas OpenVidu ships as one integrated stack. Both are Apache 2.0 licensed; Jitsi's paid option is 8x8's hosted Jitsi as a Service rather than a self-hosted PRO tier.
+
+:octicons-arrow-right-24: **[Read the full OpenVidu vs Jitsi comparison](../openvidu-vs-jitsi.md)**, covering recording (Egress vs Jibri), scaling (Elastic/HA vs Octo), SDKs and pricing.
+
 ## OpenVidu vs SaaS solutions
 
 This includes many services like [Agora :fontawesome-solid-external-link:{.external-link-icon}](https://www.agora.io/){:target="_blank"}, [GetStream :fontawesome-solid-external-link:{.external-link-icon}](https://getstream.io/){:target="_blank"}, [Daily :fontawesome-solid-external-link:{.external-link-icon}](https://www.daily.co/){:target="_blank"}, [Vonage :fontawesome-solid-external-link:{.external-link-icon}](https://www.vonage.com/communications-apis/video/){:target="_blank"}, [Jitsi as a Service :fontawesome-solid-external-link:{.external-link-icon}](https://jaas.8x8.vc/#/){:target="_blank"}, [Whereby :fontawesome-solid-external-link:{.external-link-icon}](https://whereby.com/){:target="_blank"}, [Zoom SDK :fontawesome-solid-external-link:{.external-link-icon}](https://developers.zoom.us/docs/video-sdk/){:target="_blank"}, [Dolby Millicast :fontawesome-solid-external-link:{.external-link-icon}](https://dolby.io/){:target="_blank"}, [Amazon Chime SDK :fontawesome-solid-external-link:{.external-link-icon}](https://aws.amazon.com/chime/chime-sdk/){:target="_blank"}.
@@ -87,6 +93,12 @@ SFUs are generally low-level tools. Using them directly to implement real-time a
 OpenVidu uses mediasoup internally to transmit media streams. We have embedded mediasoup as the WebRTC engine right at the core of LiveKit Open Source, which allows OpenVidu to offer the fantastic APIs and SDKs of LiveKit while providing the cutting-edge performance of mediasoup. Learn more about mediasoup integration in section [Performance](./self-hosting/production-ready/performance.md).
 
 :octicons-arrow-right-24: **[Read the full OpenVidu vs mediasoup comparison](../openvidu-vs-mediasoup.md)**, including exactly what mediasoup leaves for you to build yourself if you use it directly.
+
+## OpenVidu vs Janus
+
+[Janus :fontawesome-solid-external-link:{.external-link-icon}](https://janus.conf.meetecho.com/){:target="_blank"} is a general-purpose, plugin-based [WebRTC SFU](#openvidu-vs-sfus) from Meetecho. Its VideoRoom plugin provides a basic multistream room, but signaling, authentication, managed recording and a REST API are left for the integrating application to build — and it's released under GPL v3, a copyleft license unlike OpenVidu's Apache 2.0.
+
+:octicons-arrow-right-24: **[Read the full OpenVidu vs Janus comparison](../openvidu-vs-janus.md)**, including exactly what Janus leaves for you to build yourself if you use it directly.
 
 ## OpenVidu vs Microsoft Teams, Google Meet, Zoom
 

--- a/docs/openvidu-vs-janus.md
+++ b/docs/openvidu-vs-janus.md
@@ -88,8 +88,7 @@ That said, Janus ships more out of the box than a bare media engine:
   Android.
 - **No cross-instance clustering.** Each Janus instance is standalone; running several behind a
   single conferencing experience is your own load-balancing and signaling design.
-- **A copyleft license to account for.** Janus is GPL v3 — a real practical difference from
-  OpenVidu's Apache 2.0, worth checking against your own project's licensing model before you build
+- **A copyleft license to account for.** Janus is GPL v3, worth checking against your own project's licensing model before you build
   on it (Meetecho also sells a commercial license if GPL doesn't fit).
 
 ## OpenVidu already built all of this — on top of its own stack
@@ -109,7 +108,7 @@ That said, Janus ships more out of the box than a bare media engine:
 ## When raw Janus is still the right call
 
 To be fair about it: Janus's plugin ecosystem reaches further than conferencing rooms alone — SIP
-gateway integrations, one-to-many streaming, and other topologies its plugins already cover. Teams
+gateway integrations (although that's also possible through [LiveKit's SIP API](https://docs.livekit.io/reference/telephony/sip-api/)), one-to-many streaming, and other topologies its plugins already cover. Teams
 building one of those use cases, or something custom enough that a room-centric platform like
 OpenVidu doesn't fit, get real value from working directly with Janus's core-plus-plugins design.
 

--- a/docs/openvidu-vs-janus.md
+++ b/docs/openvidu-vs-janus.md
@@ -1,0 +1,153 @@
+---
+title: "OpenVidu vs Janus: Platform vs Raw WebRTC Gateway"
+description: "Janus is a general-purpose WebRTC gateway, not a platform. See exactly what it leaves for you to build — signaling, rooms, auth, recording, API."
+# Structured Q&A metadata for this page's FAQ section. It feeds the JSON-LD
+# (schema.org FAQPage) emitted by overrides/partials/json-ld.html. Keep in
+# sync with the page content below: 'anchor' must match the heading id, and
+# each answer must summarize the visible content of its section.
+faq:
+  - anchor: is-janus-a-competitor-to-openvidu
+    question: "Is Janus a competitor to OpenVidu?"
+    answer: >-
+      Not directly — Janus is a general-purpose WebRTC gateway, not a finished platform. Its
+      VideoRoom plugin provides a basic multistream SFU room, but signaling design, authentication,
+      managed recording, a REST API and a dashboard are left for the integrating application to
+      build. OpenVidu is a full platform where all of that is already built.
+  - anchor: does-openvidu-use-janus
+    question: "Does OpenVidu use Janus?"
+    answer: >-
+      No. OpenVidu is a fork of LiveKit that uses Pion or mediasoup as its media engine, not Janus.
+      Janus is an independent project from Meetecho with its own plugin architecture.
+  - anchor: what-license-is-janus-released-under
+    question: "What license is Janus released under?"
+    answer: >-
+      Janus is released under the GNU GPL v3, with a commercial license available from Meetecho for
+      teams that don't want GPL's copyleft obligations. This is a real practical difference from
+      OpenVidu COMMUNITY's Apache 2.0 license, worth checking against your own project's licensing
+      requirements before you build on it.
+  - anchor: can-i-use-janus-directly-instead-of-a-platform
+    question: "Can I use Janus directly instead of a platform?"
+    answer: >-
+      Yes, and for teams building something beyond a standard video-conferencing room — a custom
+      SIP gateway, a broadcast/streaming topology, or another use case covered by Janus's plugin
+      ecosystem — it can be the right call. Go in aware of the scope: you're also taking on
+      authentication, room persistence beyond VideoRoom's basics, managed recording, a REST API,
+      a dashboard, and native mobile SDKs yourself.
+hide:
+  - navigation
+  - toc
+  - footer
+  - search-bar
+  - version-selector
+tags: []
+---
+
+# OpenVidu vs Janus
+
+**Janus isn't a competing platform** — it's a general-purpose, plugin-based WebRTC gateway from
+Meetecho, comparable in spirit to [mediasoup](openvidu-vs-mediasoup.md) but broader in scope: its
+plugins cover conferencing, SIP gateways, streaming and more, not conferencing rooms alone. If
+you're evaluating "build directly on Janus" against "use OpenVidu," here's exactly what Janus
+leaves for you to build yourself, and what OpenVidu already built on its own stack.
+
+<div style="text-align: center; margin: 2em 0;" markdown>
+
+[Get started with Platform](docs/index.md){ .md-button .md-button--primary }
+[Compare with a full platform instead](openvidu-vs-jitsi.md){ .md-button }
+
+</div>
+
+## What Janus gives you
+
+Janus follows a **core-plus-plugins** design: the core handles WebRTC session setup and JSON
+message exchange with browsers, while server-side plugins implement everything else. Its own docs
+are explicit that the core provides *"no functionality per se other than implementing the means to
+set up a WebRTC media communication."*
+
+That said, Janus ships more out of the box than a bare media engine:
+
+- The **VideoRoom plugin** provides an actual multistream SFU room concept — closer to a room
+  primitive than mediasoup's raw Workers/Routers/Transports, though still far short of a full
+  platform (see below).
+- Multiple transport bindings are bundled: REST/HTTP, WebSockets, RabbitMQ, MQTT and Unix sockets.
+- An **Admin/Monitor API**, authenticated via JWT or HTTP Basic Auth, for inspecting sessions and
+  handles at the media level.
+- Recording at the plugin level: VideoRoom can dump raw per-user audio/video tracks to `.mjr`
+  files.
+
+## What you'd still build yourself
+
+- **No application-level authentication.** The Admin/Monitor API has its own auth, but nothing
+  protects your actual conferencing rooms — that's your signaling layer's job to build.
+- **No managed recording pipeline.** VideoRoom's `.mjr` dumps are raw per-track files; turning them
+  into a normal video file needs the separate `janus-pp-rec` post-processing tool, run by you.
+- **No S3 or other managed storage** for whatever recordings you produce.
+- **No admin dashboard.** The Admin/Monitor API is programmatic only — third-party community
+  dashboards exist, but nothing official ships with the project.
+- **No official native mobile SDKs.** Only community-maintained wrappers are available for iOS and
+  Android.
+- **No cross-instance clustering.** Each Janus instance is standalone; running several behind a
+  single conferencing experience is your own load-balancing and signaling design.
+- **A copyleft license to account for.** Janus is GPL v3 — a real practical difference from
+  OpenVidu's Apache 2.0, worth checking against your own project's licensing model before you build
+  on it (Meetecho also sells a commercial license if GPL doesn't fit).
+
+## OpenVidu already built all of this — on top of its own stack
+
+| | **OpenVidu** | **Janus** |
+| --- | --- | --- |
+| License | Apache 2.0<span class="openvidu-tag openvidu-community-tag" style="font-size: .7em">COMMUNITY</span> / commercial<span class="openvidu-tag openvidu-pro-tag" style="font-size: .7em">PRO</span> | GPL v3 (commercial license available) |
+| Room/session model | [Bundled](docs/developing-your-openvidu-app/how-to.md#manage-rooms) | Basic, via the VideoRoom plugin only |
+| Authentication | [JWT tokens with grants](docs/developing-your-openvidu-app/how-to.md#generate-access-tokens), bundled | Not provided for application rooms |
+| Recording (Egress) | [Bundled](docs/developing-your-openvidu-app/how-to.md#recording), S3-compatible storage | Raw `.mjr` dumps, manual post-processing |
+| Server/REST API | Full [server API](docs/developing-your-openvidu-app/how-to.md) | Admin/Monitor API only (session-level, not app-level) |
+| Webhooks | Bundled [event set](docs/developing-your-openvidu-app/how-to.md#webhooks) | None |
+| Dashboard | [OpenVidu Dashboard](docs/self-hosting/production-ready/observability/openvidu-dashboard.md) | None official |
+| Client SDKs | [8 SDKs, including native Android and iOS](docs/tutorials/application-client/index.md) | Community-maintained only |
+| Clustering | [One-click automated deployment](docs/self-hosting/deployment-types.md) with autoscaling on 5 cloud providers | Your own orchestration across standalone instances |
+
+## When raw Janus is still the right call
+
+To be fair about it: Janus's plugin ecosystem reaches further than conferencing rooms alone — SIP
+gateway integrations, one-to-many streaming, and other topologies its plugins already cover. Teams
+building one of those use cases, or something custom enough that a room-centric platform like
+OpenVidu doesn't fit, get real value from working directly with Janus's core-plus-plugins design.
+
+For those specific cases, building on Janus is the right call, as long as you accept the GPL
+licensing and the list above as work you're signing up to own. For most teams building a standard
+real-time video application, that's a lot of platform to build on top of a gateway, when OpenVidu
+already ships it.
+
+## Frequently asked questions
+
+### Is Janus a competitor to OpenVidu?
+
+Not directly — Janus is a general-purpose WebRTC gateway, not a finished platform. Its VideoRoom
+plugin provides a basic multistream SFU room, but signaling design, authentication, managed
+recording, a REST API and a dashboard are left for the integrating application to build. OpenVidu
+is a full platform where all of that is already built.
+
+### Does OpenVidu use Janus?
+
+No. OpenVidu is a fork of LiveKit that uses Pion or mediasoup as its media engine, not Janus. Janus
+is an independent project from Meetecho with its own plugin architecture.
+
+### What license is Janus released under?
+
+Janus is released under the GNU GPL v3, with a commercial license available from Meetecho for teams
+that don't want GPL's copyleft obligations. This is a real practical difference from OpenVidu
+<span class="openvidu-tag openvidu-community-tag" style="font-size: .8em">COMMUNITY</span>'s Apache 2.0 license, worth checking against your own project's licensing requirements
+before you build on it.
+
+### Can I use Janus directly instead of a platform?
+
+Yes, and for teams building something beyond a standard video-conferencing room — a custom SIP
+gateway, a broadcast/streaming topology, or another use case covered by Janus's plugin ecosystem —
+it can be the right call. Go in aware of the scope: you're also taking on authentication, room
+persistence beyond VideoRoom's basics, managed recording, a REST API, a dashboard, and native
+mobile SDKs yourself.
+
+<div style="text-align: center; margin: 2em 0;" markdown>
+
+[Start with a tutorial](docs/tutorials/application-server/index.md){ .md-button .md-button--primary }
+</div>

--- a/docs/openvidu-vs-jitsi.md
+++ b/docs/openvidu-vs-jitsi.md
@@ -59,7 +59,7 @@ The biggest practical difference isn't a feature — it's what you have to deplo
 | Components to operate | A [fork of LiveKit](openvidu-vs-livekit.md), optionally with mediasoup as the media engine<span class="openvidu-tag openvidu-pro-tag" style="font-size: .7em">PRO</span> and [OpenVidu Meet](/meet/) as a web frontend — one integrated stack | Prosody (XMPP signaling), Jicofo (conference focus), Jitsi Videobridge (SFU, Java), and the Jitsi Meet web frontend — four separately-versioned components, a single bundle|
 | License | Apache 2.0<span class="openvidu-tag openvidu-community-tag" style="font-size: .7em">COMMUNITY</span> / commercial<span class="openvidu-tag openvidu-pro-tag" style="font-size: .7em">PRO</span> | Apache 2.0 |
 | Recording/streaming | [Egress bundled by default](docs/developing-your-openvidu-app/how-to.md), no extra hardware sizing | Jibri, can be deployed as an additional bundle |
-| Horizontal scaling | [Elastic & HA modes](docs/self-hosting/production-ready/scalability.md)<span class="openvidu-tag openvidu-pro-tag" style="font-size: .7em">PRO</span>, one product to configure & one-click deploy for 5 cloud providers | Multiple Videobridges plus the Octo relay protocol, configured to match across JVB and Jicofo |
+| Horizontal scaling | [Elastic & HA modes](docs/self-hosting/production-ready/scalability.md)<span class="openvidu-tag openvidu-pro-tag" style="font-size: .7em">PRO</span>, one product to configure & one-click deploy for 5 cloud providers | Octo relays media across an existing pool of Videobridges; actually growing that pool needs a separate `jitsi-autoscaler` service, supporting only Oracle OCI, DigitalOcean or a custom provider you implement |
 | Admin dashboard | [OpenVidu Dashboard](docs/self-hosting/production-ready/observability/openvidu-dashboard.md)<span class="openvidu-tag openvidu-community-tag" style="font-size: .7em">COMMUNITY</span>, per-room and per-participant views<span class="openvidu-tag openvidu-pro-tag" style="font-size: .7em">PRO</span> | None bundled |
 | Ready-to-use app | [OpenVidu Meet](meet/index.md), embeddable via [iframe](/meet/embedded/step-by-step-guide/#use-an-iframe) or [web component](/meet/embedded/step-by-step-guide/#use-the-web-component) | Jitsi Meet, embeddable via iframe, lib-jitsi-meet, or native SDKs |
 | Hosted/cloud option | None — [self-hosted](docs/self-hosting/deployment-types.md) only, on your own infrastructure. One-click deploy for [5 cloud providers](docs/self-hosting/single-node/index.md) | [Jitsi as a Service](https://jaas.8x8.vc/) (8x8), MAU-priced |
@@ -79,17 +79,25 @@ resource cost: each simultaneous recording needs its own Jibri instance (typical
 separate hardware from the videobridge, since it can degrade conference performance otherwise. Five
 concurrent recordings means five separate Jibri instances to provision and keep healthy.
 
-## Scaling: Elastic/HA vs Octo
+## Scaling: Elastic/HA vs Octo plus a separate autoscaler
 
 Both projects scale horizontally, but the operational shape differs. OpenVidu's
 [Elastic and HA modes](docs/self-hosting/production-ready/scalability.md) are delivered as a
 configured product: you pick a mode and OpenVidu's automated deployments handle the rest.
 
-Jitsi scales by running multiple Videobridge instances connected through **Octo**, a relay protocol
-that lets bridges in different regions forward media to each other so participants connect to their
-nearest bridge within one conference. It's a genuinely capable mechanism — but it's also DIY
-infrastructure: Octo has to be enabled with matching settings on both the Videobridge and Jicofo, or
-bridges crash, and sharding across Prosody/Jicofo/JVB clusters is your own design to get right.
+Jitsi splits the problem into two layers, and it's worth being precise about which one **Octo**
+actually solves. Octo is a relay protocol that lets Videobridge instances forward media to each
+other, so a conference can span bridges in different regions with participants connecting to their
+nearest one — but it only routes media across a pool of bridges that's already running. It doesn't
+decide how many bridges to run: that's Jicofo's job in real time (bridge selection from reported
+load), and it's a fixed pool unless something else grows or shrinks it. Actually autoscaling that
+pool needs a third, separate component — [`jitsi-autoscaler`](https://github.com/jitsi/jitsi-autoscaler),
+its own microservice with sidecars on every Videobridge reporting load to a Redis-backed
+autoscaler, which then launches or kills instances via a cloud-provider integration. It's real, but
+it's DIY: its own deployment, its own Redis, and only Oracle OCI, DigitalOcean or a custom provider
+you write yourself are supported — no AWS/Azure/GCP integration out of the box. On top of that, Octo
+itself has to be enabled with matching settings on both the Videobridge and Jicofo, or bridges
+crash, and sharding across Prosody/Jicofo/JVB clusters is your own design to get right.
 
 ## Client integration: SDKs
 

--- a/docs/openvidu-vs-jitsi.md
+++ b/docs/openvidu-vs-jitsi.md
@@ -1,0 +1,168 @@
+---
+title: "OpenVidu vs Jitsi: Two Self-Hosted Platforms Compared"
+description: "OpenVidu and Jitsi are both open-source, self-hosted video platforms. Compare architecture, recording, scaling, SDKs and pricing to pick the right one."
+# Structured Q&A metadata for this page's FAQ section. It feeds the JSON-LD
+# (schema.org FAQPage) emitted by overrides/partials/json-ld.html. Keep in
+# sync with the page content below: 'anchor' must match the heading id, and
+# each answer must summarize the visible content of its section.
+faq:
+  - anchor: is-openvidu-a-fork-of-jitsi
+    question: "Is OpenVidu a fork of Jitsi?"
+    answer: >-
+      No. Unlike its relationship to LiveKit, OpenVidu shares no codebase with Jitsi. Both are
+      independent, open-source, self-hosted video platforms, so this is a peer comparison, not a
+      compatibility one — there's no SDK-level migration path between them.
+  - anchor: is-jitsi-free-to-self-host
+    question: "Is Jitsi free to self-host?"
+    answer: >-
+      Yes. Jitsi Meet, Jicofo and Jitsi Videobridge are all Apache 2.0, the same license as OpenVidu
+      COMMUNITY. The paid option is 8x8's hosted Jitsi as a Service (JaaS), not a self-hosted PRO
+      tier — Jitsi itself has no self-hosted paid edition the way OpenVidu does.
+  - anchor: does-jitsi-have-a-recording-feature
+    question: "Does Jitsi have a recording feature?"
+    answer: >-
+      Yes, via Jibri, a component that drives a headless Chrome browser and ffmpeg to capture
+      exactly what a participant sees. It's accurate but resource-heavy: each simultaneous
+      recording needs its own dedicated Jibri instance, typically 8-12GB of RAM, separate from the
+      videobridge hardware.
+  - anchor: can-i-embed-jitsi-in-my-own-app
+    question: "Can I embed Jitsi in my own app?"
+    answer: >-
+      Yes — via an iframe API, the lower-level lib-jitsi-meet JavaScript library for a fully custom
+      UI, or pre-built iOS/Android/React Native SDKs that reuse the Jitsi Meet app experience. This
+      makes Jitsi span both the "ready-to-use app" and "SDK" audiences that OpenVidu splits into
+      Meet and Platform.
+hide:
+  - navigation
+  - toc
+  - footer
+  - search-bar
+  - version-selector
+tags: []
+---
+
+# OpenVidu vs Jitsi
+
+OpenVidu and Jitsi are both **open-source, self-hosted video platforms** — but built on different
+architectures, with different defaults for what you get out of the box. Jitsi is not a fork or
+derivative of anything OpenVidu uses (unlike [OpenVidu vs LiveKit](openvidu-vs-livekit.md), this is
+a genuine peer comparison), and it's mature enough to have picked up massive real-world scale during
+its COVID-era adoption wave. This page compares the two on architecture, recording, scaling, client
+SDKs and pricing.
+
+<div style="text-align: center; margin: 2em 0;" markdown>
+
+[Get started with Platform](docs/index.md){ .md-button .md-button--primary }
+[Compare Meet vs Platform](openvidu-meet-vs-openvidu-platform.md){ .md-button }
+
+</div>
+
+!!! tip "Jitsi spans both Meet and Platform"
+    Jitsi Meet works both as a ready-to-use application and, via its SDKs, as a building block for
+    a custom app — the two audiences OpenVidu splits into **OpenVidu Meet** and **OpenVidu
+    Platform**. If you already know which one you need, the comparison below still applies to
+    either: swap in [OpenVidu Meet](meet/index.md) wherever this page says Platform.
+
+## Architecture at a glance
+
+The biggest practical difference isn't a feature — it's what you have to deploy and keep running.
+
+| | **OpenVidu** | **Jitsi** |
+| --- | --- | --- |
+| Components to operate | A [fork of LiveKit](openvidu-vs-livekit.md), optionally with mediasoup as the media engine — one integrated stack | Prosody (XMPP signaling), Jicofo (conference focus), Jitsi Videobridge (SFU, Java), and the Jitsi Meet web frontend — four separately-versioned components |
+| License | Apache 2.0<span class="openvidu-tag openvidu-community-tag" style="font-size: .7em">COMMUNITY</span> / commercial<span class="openvidu-tag openvidu-pro-tag" style="font-size: .7em">PRO</span> | Apache 2.0 |
+| Recording/streaming | [Egress bundled by default](docs/developing-your-openvidu-app/how-to.md), no extra hardware sizing | Jibri: a dedicated headless-Chrome-plus-ffmpeg instance per simultaneous recording |
+| Horizontal scaling | [Elastic & HA modes](docs/self-hosting/production-ready/scalability.md)<span class="openvidu-tag openvidu-pro-tag" style="font-size: .7em">PRO</span>, one product to configure | Multiple Videobridges plus the Octo relay protocol, configured to match across JVB and Jicofo |
+| Admin dashboard | [OpenVidu Dashboard](docs/self-hosting/production-ready/observability/openvidu-dashboard.md)<span class="openvidu-tag openvidu-community-tag" style="font-size: .7em">COMMUNITY</span>, per-room and per-participant views<span class="openvidu-tag openvidu-pro-tag" style="font-size: .7em">PRO</span> | None bundled |
+| Ready-to-use app | [OpenVidu Meet](meet/index.md), optionally [embeddable](meet/embedded/intro.md) | Jitsi Meet, embeddable via iframe, lib-jitsi-meet, or native SDKs |
+| Hosted/cloud option | None — self-hosted only, on your own infrastructure | [Jitsi as a Service](https://jaas.8x8.vc/) (8x8), MAU-priced |
+| Pricing | Free<span class="openvidu-tag openvidu-community-tag" style="font-size: .7em">COMMUNITY</span>, flat **$0.0006/core/minute**<span class="openvidu-tag openvidu-pro-tag" style="font-size: .7em">PRO</span> | Free self-hosted; JaaS from **$0.35/MAU** (decreasing with volume), recording is a separate $0.01/min add-on |
+
+## Recording: bundled Egress vs Jibri
+
+This is the sharpest operational difference between the two projects. OpenVidu <span class="openvidu-tag openvidu-community-tag" style="font-size: .8em">COMMUNITY</span> ships
+[Egress](docs/developing-your-openvidu-app/how-to.md) wired up by default, writing to
+S3-compatible storage out of the box.
+
+Jitsi's Jibri takes a different, more literal approach: it opens a real headless Chrome browser
+pointed at the meeting, renders it in a virtual framebuffer, and captures the output with ffmpeg —
+recording exactly what a participant would see, custom branding included. The tradeoff is
+resource cost: each simultaneous recording needs its own Jibri instance (typically 8GB of RAM for
+1080x720, more for higher resolutions), and Jitsi's own operators recommend running Jibri on
+separate hardware from the videobridge, since it can degrade conference performance otherwise. Five
+concurrent recordings means five separate Jibri instances to provision and keep healthy.
+
+## Scaling: Elastic/HA vs Octo
+
+Both projects scale horizontally, but the operational shape differs. OpenVidu's
+[Elastic and HA modes](docs/self-hosting/production-ready/scalability.md) are delivered as a
+configured product: you pick a mode and OpenVidu's automated deployments handle the rest.
+
+Jitsi scales by running multiple Videobridge instances connected through **Octo**, a relay protocol
+that lets bridges in different regions forward media to each other so participants connect to their
+nearest bridge within one conference. It's a genuinely capable mechanism — but it's also DIY
+infrastructure: Octo has to be enabled with matching settings on both the Videobridge and Jicofo, or
+bridges crash, and sharding across Prosody/Jicofo/JVB clusters is your own design to get right.
+
+## Client integration: SDKs
+
+Jitsi offers a broader set of integration depths than a typical low-level SFU: an iframe-based
+External API for the simplest embed, the lower-level `lib-jitsi-meet` JavaScript library if you want
+to build your own UI on top of Jitsi's connection/room primitives, and pre-built iOS, Android and
+React Native SDKs that reuse the Jitsi Meet app experience directly.
+
+OpenVidu's approach is the LiveKit-compatible SDK set — 8 client SDKs including native iOS and
+Android — plus [OpenVidu Meet's own embedding path](meet/embedded/intro.md) for teams that want the
+finished app experience inside their product rather than building a custom UI from primitives.
+
+## Where Jitsi still has the edge
+
+To be direct about it: Jitsi has years more real-world deployment at extreme scale — it saw a huge
+adoption wave during the pandemic and is embedded in products well beyond video conferencing
+proper — and Jibri's browser-based recording captures pixel-perfect output (custom UI, branding and
+all) in a way an RTP-based Egress pipeline doesn't attempt to. If your priority is a long
+track record at very large scale, or recordings that must exactly match what participants visually
+saw, Jitsi's approach has real advantages.
+
+## Pricing
+
+Both projects are free to self-host under Apache 2.0. The difference shows up if you want a hosted
+option or paid support: OpenVidu <span class="openvidu-tag openvidu-pro-tag" style="font-size: .8em">PRO</span> is a flat **$0.0006 per core per minute** for
+self-hosted Elastic/HA deployments in your own infrastructure, while 8x8's JaaS is a *hosted*
+Monthly-Active-User model starting at $0.35/MAU (with a 25-MAU free developer tier), and charges
+recording separately at $0.01/minute. See [worked examples](pricing.md) for OpenVidu's concrete
+monthly costs at several cluster sizes.
+
+## Frequently asked questions
+
+### Is OpenVidu a fork of Jitsi?
+
+No. Unlike its relationship to LiveKit, OpenVidu shares no codebase with Jitsi. Both are
+independent, open-source, self-hosted video platforms, so this is a peer comparison, not a
+compatibility one — there's no SDK-level migration path between them.
+
+### Is Jitsi free to self-host?
+
+Yes. Jitsi Meet, Jicofo and Jitsi Videobridge are all Apache 2.0, the same license as OpenVidu
+<span class="openvidu-tag openvidu-community-tag" style="font-size: .8em">COMMUNITY</span>. The paid option is 8x8's hosted Jitsi as a Service (JaaS), not a self-hosted PRO
+tier — Jitsi itself has no self-hosted paid edition the way OpenVidu does.
+
+### Does Jitsi have a recording feature?
+
+Yes, via Jibri, a component that drives a headless Chrome browser and ffmpeg to capture exactly
+what a participant sees. It's accurate but resource-heavy: each simultaneous recording needs its
+own dedicated Jibri instance, typically 8-12GB of RAM, separate from the videobridge hardware.
+
+### Can I embed Jitsi in my own app?
+
+Yes — via an iframe API, the lower-level `lib-jitsi-meet` JavaScript library for a fully custom UI,
+or pre-built iOS/Android/React Native SDKs that reuse the Jitsi Meet app experience. This makes
+Jitsi span both the "ready-to-use app" and "SDK" audiences that OpenVidu splits into Meet and
+Platform.
+
+<div style="text-align: center; margin: 2em 0;" markdown>
+
+[Start with a tutorial](docs/tutorials/application-server/index.md){ .md-button .md-button--primary }
+[Evaluating a raw SFU instead?](openvidu-vs-janus.md){ .md-button }
+
+</div>

--- a/docs/openvidu-vs-jitsi.md
+++ b/docs/openvidu-vs-jitsi.md
@@ -6,12 +6,6 @@ description: "OpenVidu and Jitsi are both open-source, self-hosted video platfor
 # sync with the page content below: 'anchor' must match the heading id, and
 # each answer must summarize the visible content of its section.
 faq:
-  - anchor: is-openvidu-a-fork-of-jitsi
-    question: "Is OpenVidu a fork of Jitsi?"
-    answer: >-
-      No. Unlike its relationship to LiveKit, OpenVidu shares no codebase with Jitsi. Both are
-      independent, open-source, self-hosted video platforms, so this is a peer comparison, not a
-      compatibility one — there's no SDK-level migration path between them.
   - anchor: is-jitsi-free-to-self-host
     question: "Is Jitsi free to self-host?"
     answer: >-
@@ -44,24 +38,17 @@ tags: []
 # OpenVidu vs Jitsi
 
 OpenVidu and Jitsi are both **open-source, self-hosted video platforms** — but built on different
-architectures, with different defaults for what you get out of the box. Jitsi is not a fork or
-derivative of anything OpenVidu uses (unlike [OpenVidu vs LiveKit](openvidu-vs-livekit.md), this is
-a genuine peer comparison), and it's mature enough to have picked up massive real-world scale during
-its COVID-era adoption wave. This page compares the two on architecture, recording, scaling, client
+architectures, with different defaults for what you get out of the box. This page compares the two on architecture, recording, scaling, client
 SDKs and pricing.
 
 <div style="text-align: center; margin: 2em 0;" markdown>
-
-[Get started with Platform](docs/index.md){ .md-button .md-button--primary }
-[Compare Meet vs Platform](openvidu-meet-vs-openvidu-platform.md){ .md-button }
 
 </div>
 
 !!! tip "Jitsi spans both Meet and Platform"
     Jitsi Meet works both as a ready-to-use application and, via its SDKs, as a building block for
     a custom app — the two audiences OpenVidu splits into **OpenVidu Meet** and **OpenVidu
-    Platform**. If you already know which one you need, the comparison below still applies to
-    either: swap in [OpenVidu Meet](meet/index.md) wherever this page says Platform.
+    Platform**.
 
 ## Architecture at a glance
 
@@ -69,13 +56,13 @@ The biggest practical difference isn't a feature — it's what you have to deplo
 
 | | **OpenVidu** | **Jitsi** |
 | --- | --- | --- |
-| Components to operate | A [fork of LiveKit](openvidu-vs-livekit.md), optionally with mediasoup as the media engine — one integrated stack | Prosody (XMPP signaling), Jicofo (conference focus), Jitsi Videobridge (SFU, Java), and the Jitsi Meet web frontend — four separately-versioned components |
+| Components to operate | A [fork of LiveKit](openvidu-vs-livekit.md), optionally with mediasoup as the media engine<span class="openvidu-tag openvidu-pro-tag" style="font-size: .7em">PRO</span> and [OpenVidu Meet](/meet/) as a web frontend — one integrated stack | Prosody (XMPP signaling), Jicofo (conference focus), Jitsi Videobridge (SFU, Java), and the Jitsi Meet web frontend — four separately-versioned components, a single bundle|
 | License | Apache 2.0<span class="openvidu-tag openvidu-community-tag" style="font-size: .7em">COMMUNITY</span> / commercial<span class="openvidu-tag openvidu-pro-tag" style="font-size: .7em">PRO</span> | Apache 2.0 |
-| Recording/streaming | [Egress bundled by default](docs/developing-your-openvidu-app/how-to.md), no extra hardware sizing | Jibri: a dedicated headless-Chrome-plus-ffmpeg instance per simultaneous recording |
-| Horizontal scaling | [Elastic & HA modes](docs/self-hosting/production-ready/scalability.md)<span class="openvidu-tag openvidu-pro-tag" style="font-size: .7em">PRO</span>, one product to configure | Multiple Videobridges plus the Octo relay protocol, configured to match across JVB and Jicofo |
+| Recording/streaming | [Egress bundled by default](docs/developing-your-openvidu-app/how-to.md), no extra hardware sizing | Jibri, can be deployed as an additional bundle |
+| Horizontal scaling | [Elastic & HA modes](docs/self-hosting/production-ready/scalability.md)<span class="openvidu-tag openvidu-pro-tag" style="font-size: .7em">PRO</span>, one product to configure & one-click deploy for 5 cloud providers | Multiple Videobridges plus the Octo relay protocol, configured to match across JVB and Jicofo |
 | Admin dashboard | [OpenVidu Dashboard](docs/self-hosting/production-ready/observability/openvidu-dashboard.md)<span class="openvidu-tag openvidu-community-tag" style="font-size: .7em">COMMUNITY</span>, per-room and per-participant views<span class="openvidu-tag openvidu-pro-tag" style="font-size: .7em">PRO</span> | None bundled |
-| Ready-to-use app | [OpenVidu Meet](meet/index.md), optionally [embeddable](meet/embedded/intro.md) | Jitsi Meet, embeddable via iframe, lib-jitsi-meet, or native SDKs |
-| Hosted/cloud option | None — self-hosted only, on your own infrastructure | [Jitsi as a Service](https://jaas.8x8.vc/) (8x8), MAU-priced |
+| Ready-to-use app | [OpenVidu Meet](meet/index.md), embeddable via [iframe](/meet/embedded/step-by-step-guide/#use-an-iframe) or [web component](/meet/embedded/step-by-step-guide/#use-the-web-component) | Jitsi Meet, embeddable via iframe, lib-jitsi-meet, or native SDKs |
+| Hosted/cloud option | None — [self-hosted](docs/self-hosting/deployment-types.md) only, on your own infrastructure. One-click deploy for [5 cloud providers](docs/self-hosting/single-node/index.md) | [Jitsi as a Service](https://jaas.8x8.vc/) (8x8), MAU-priced |
 | Pricing | Free<span class="openvidu-tag openvidu-community-tag" style="font-size: .7em">COMMUNITY</span>, flat **$0.0006/core/minute**<span class="openvidu-tag openvidu-pro-tag" style="font-size: .7em">PRO</span> | Free self-hosted; JaaS from **$0.35/MAU** (decreasing with volume), recording is a separate $0.01/min add-on |
 
 ## Recording: bundled Egress vs Jibri
@@ -134,12 +121,6 @@ recording separately at $0.01/minute. See [worked examples](pricing.md) for Open
 monthly costs at several cluster sizes.
 
 ## Frequently asked questions
-
-### Is OpenVidu a fork of Jitsi?
-
-No. Unlike its relationship to LiveKit, OpenVidu shares no codebase with Jitsi. Both are
-independent, open-source, self-hosted video platforms, so this is a peer comparison, not a
-compatibility one — there's no SDK-level migration path between them.
 
 ### Is Jitsi free to self-host?
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -276,6 +276,8 @@ not_in_nav: |
   /openvidu-meet-vs-openvidu-platform.md
   /openvidu-vs-livekit.md
   /openvidu-vs-mediasoup.md
+  /openvidu-vs-jitsi.md
+  /openvidu-vs-janus.md
   /conditions/
 
 validation:
@@ -456,6 +458,8 @@ plugins:
         - openvidu-meet-vs-openvidu-platform.md
         - openvidu-vs-livekit.md
         - openvidu-vs-mediasoup.md
+        - openvidu-vs-jitsi.md
+        - openvidu-vs-janus.md
         - pricing.md
         - support.md
         - about-us.md

--- a/publish-tool/ovweb.yaml
+++ b/publish-tool/ovweb.yaml
@@ -30,6 +30,8 @@ layout:
     - openvidu-meet-vs-openvidu-platform
     - openvidu-vs-livekit
     - openvidu-vs-mediasoup
+    - openvidu-vs-jitsi
+    - openvidu-vs-janus
     - conditions
     - blog
     - about-us


### PR DESCRIPTION
## Summary

- Adds two standalone comparison landing pages, following the same convention as `openvidu-vs-livekit.md`/`openvidu-vs-mediasoup.md` (#98): non-versioned root page, `hide: [navigation, toc, footer, search-bar, version-selector]`, `faq` frontmatter feeding the `FAQPage` JSON-LD.
  - `docs/openvidu-vs-jitsi.md` — a peer comparison (not a fork/compatibility one, unlike LiveKit): architecture (OpenVidu's unified stack vs Jitsi's Prosody/Jicofo/JVB/web split), recording (bundled Egress vs Jibri's headless-Chrome-per-recording approach), scaling (Elastic/HA vs Octo), client SDK integration depth, an honest section on where Jitsi still has the edge (deployment maturity at scale, pixel-perfect browser-rendered recording), and pricing (OpenVidu Pro's flat per-core-minute vs 8x8 JaaS's MAU model).
  - `docs/openvidu-vs-janus.md` — reframes Janus (Meetecho's general-purpose, plugin-based WebRTC gateway) as not a competing platform, in the same spirit as the existing mediasoup page but scoped to what Janus's own docs and VideoRoom plugin actually provide (a basic room concept, several transport bindings, an Admin/Monitor API) versus what's left to build (app-level auth, managed recording beyond raw `.mjr` dumps, a dashboard, mobile SDKs, cross-instance clustering) — and flags the GPL v3 licensing difference from OpenVidu's Apache 2.0.
- Both pages address commercial-intent queries named in `openvidu-marketing`'s issue #9 (`openvidu vs jitsi`, `openvidu vs janus`) that currently have no dedicated OpenVidu page.
- Added a new "OpenVidu vs Jitsi" section and a new "OpenVidu vs Janus" section to `docs/docs/comparing-openvidu.md`, each linking to the corresponding full page — Jitsi placed as a peer platform alongside the LiveKit section, Janus placed alongside the existing mediasoup section under "OpenVidu vs SFUs". Updated the page's own title/description to mention Jitsi/Janus.
- Registered both new pages in `mkdocs.yml`'s `not_in_nav` and in the `llmstxt` plugin's `Product and pricing` section, matching how `openvidu-vs-livekit.md`/`openvidu-vs-mediasoup.md` are registered.
- Sourced from Jitsi's and Janus's own official documentation and 8x8's published JaaS pricing (see links inline in each page) — not derived from an internal comparative study doc, since none existed yet for these two competitors.
- Relates to `openvidu-marketing#9` (tracked as new sub-issue 9-c, splitting Jitsi out of 9-b which also names Twilio Video, still separately tracked).

## Test plan

- [x] Manually verified every FAQ `anchor` in frontmatter matches the actual generated heading id for its corresponding `###` heading.
- [x] Manually verified all internal links use the plain relative convention (`docs/...`, `meet/...`, sibling `.md` files) matching neighboring pages, with no hand-written `/latest/` prefix.
- [x] Verified the `mkdocs.yml` YAML edits (`not_in_nav` block scalar, `llmstxt.sections` list) match the existing indentation/formatting exactly.
- [ ] **Not done: a local `mkdocs build`.** No `mkdocs`/the custom plugin stack was available in this environment to build and screenshot the pages before opening this PR — please build and eyeball-check rendering (tables, tab buttons, FAQ JSON-LD) before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)